### PR TITLE
more precise unfold typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2718,8 +2718,8 @@ declare namespace R {
          * to stop iteration or an array of length 2 containing the value to add to the resulting
          * list and the seed to be used in the next call to the iterator function.
          */
-        unfold<T, TResult>(fn: (seed: T) => TResult[]|boolean, seed: T): TResult[];
-        unfold<T, TResult>(fn: (seed: T) => TResult[]|boolean): (seed: T) => TResult[];
+        unfold<T, TResult>(fn: (seed: T) => [TResult, T]|false, seed: T): TResult[];
+        unfold<T, TResult>(fn: (seed: T) => [TResult, T]|false): (seed: T) => TResult[];
         // unfold<T, TResult>: CurriedFunction2<(seed: T) => TResult[]|boolean, T, TResult[]>;
 
         /**


### PR DESCRIPTION
It sticks to the definition of unfold and actually works on real code whereas the previous definition was totally wrong.
