### PR TITLE
Fixed sortWith and head generic type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1030,7 +1030,7 @@ declare namespace R {
          * Returns the first element in a list.
          * In some libraries this function is named `first`.
          */
-        head<T extends List<any>>(list: T): T[0];
+        head<T extends List<any>>(list: T): any;
         // tuple attempts; it doesn't like these.
         head<T>(list: [T]): T;
         head<T0, T1>(list: [T0, T1]): T0;
@@ -2482,8 +2482,8 @@ declare namespace R {
         /**
          * Sorts a list according to a list of comparators.
          */
-        sortWith(comparators: List<(a: T, b: T) => number>, list: List<T>): T[];
-        sortWith(comparators: List<(a: T, b: T) => number>): (list: List<T>) => T[];
+        sortWith<T>(comparators: List<(a: T, b: T) => number>, list: List<T>): T[];
+        sortWith<T>(comparators: List<(a: T, b: T) => number>): (list: List<T>) => T[];
         // sortWith: CurriedFunction2<List<(a: T, b: T) => number>, List<T>, T[]>;
 
         /**


### PR DESCRIPTION
# Problem head
In the head declaration we are supposed to indicate the type of the parameter to return as opposed to return the actual value from the type. 
## Symptom
This creates a compile error. 
## Solution
Based on the declaration, as our T is a List<any> then T[0] will be of type any.

---

# Problem sortWith
sortWith has dependency on type T which is never declared as generic.
## Sympton
This creates a compile error. 
## Solution
Add T as a generic type for the method declaration of sortWith