### PR TITLE
genCurried -- add scripts to curry-friendly generate type signatures

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -247,3 +247,1681 @@ genCurried({
   accurate: [['T'], { prop: 'keyof T', obj: 'T' }, 'T'],
   easier: [['T'], { prop: 'Prop', obj: 'Struct<any>' }, 'T'],
 })
+
+// pathEq
+genCurried({
+  base: [
+    [],
+    {
+      p: 'string|number[]',
+      v: 'any',
+      o: 'any',
+    },
+    'boolean'
+  ]
+});
+
+// add
+genCurried({
+  base: [
+    [],
+    {
+      a: 'number',
+      b: 'number',
+    },
+    'number'
+  ]
+});
+
+// adjust
+genCurried({
+  base: [
+    ['T'],
+    {
+      fn: '(a: T) => T',
+      index: 'number',
+      list: 'List<T>'
+    },
+    'T[]'
+  ]
+});
+
+// all
+genCurried({
+  base: [
+    ['T'],
+    {
+      pred: 'Pred<T>',
+      list: 'List<T>',
+    },
+    'boolean'
+  ]
+});
+
+// allPass
+genCurried({
+  base: [
+    ['T'],
+    {
+      pred: 'Pred<T>[]',
+    },
+    'Pred<T>'
+  ]
+});
+
+// always
+genCurried({
+  base: [
+    ['T'],
+    {
+      val: 'T',
+    },
+    '() => T'
+  ]
+});
+
+// add
+genCurried({
+  base: [
+    ['T extends {and?: Function}'],
+    {
+      fn1: 'T',
+      val2: 'boolean+any'
+    },
+    'boolean'
+  ],
+  no_generics: [
+    [],
+    {
+      v1: 'any',
+      v2: 'any',
+    },
+    'boolean',
+  ]
+});
+
+// any
+genCurried({
+  base: [
+    ['T'],
+    {
+      pred: 'Pred<T>',
+      list: 'List<T>',
+    },
+    'boolean',
+  ]
+});
+
+// anyPass
+genCurried({
+  base: [
+    ['T'],
+    {
+      preds: 'Pred<T>[]',
+    },
+    'Pred<T>',
+  ]
+});
+
+// ap
+genCurried({
+  base: [
+    ['T', 'U'],
+    {
+      fns: '((a: T) => U)[]',
+      xs: 'List<T>',
+    },
+    'U[]',
+  ]
+});
+
+// aperture
+genCurried({
+  base: [
+    ['T'],
+    {
+      n: 'number',
+      list: 'List<T>',
+    },
+    'T[][]'
+  ]
+});
+
+// append
+genCurried({
+  base: [
+    ['T', 'U'],
+    {
+      el: 'U',
+      list: 'List<T>',
+    },
+    '(T & U)[]'
+  ]
+});
+
+// apply
+genCurried({
+  base: [
+    ['T', 'U', 'TResult'],
+    {
+      fn: '(arg0: T, ...args: T[]) => TResult',
+      args: 'List<U>',
+    },
+    'TResult',
+  ]
+});
+
+// applySpec
+genCurried({
+  base: [
+    ['T'],
+    {
+      obj: 'any',
+    },
+    'Variadic<T>',
+  ]
+});
+
+// ascend
+genCurried({
+  base: [
+    ['T', 'U extends Struct<any>', 'K extends keyof U'],
+    {
+      prop: 'K',
+      val: 'T',
+      obj: 'U'
+    },
+    '{[P in K]: T} & U'
+  ],
+  'any object as long as the type remains unchanged': {
+    ['T'],
+    {
+      prop: 'Prop',
+      val: 'any',
+      obj: 'T',
+    },
+    'T',
+  }
+});
+
+// assocPath
+genCurried({
+  base: [
+    ['T', 'U'],
+    {
+      path: 'Path',
+      val: 'T',
+      obj: 'U',
+    },
+    'U'
+  ]
+});
+
+// binary
+genCurried({
+  base: [
+    ['T', 'A', 'B'],
+    {
+      fn: '(a: A, b: T, ...args: any[]) => T'
+    },
+    '(a: A, b: B) => T'
+  ],
+  'non generics for return func': [
+    ['T'],
+    {
+      fn: 'Variadic<T>',
+    },
+    '(a:any, b:any) => T'
+  ]
+});
+
+// bind
+genCurried({
+  base: [
+    ['T'],
+    {
+      fn: 'Variadic<T>',
+      thisObj: '{}',
+    },
+    'Variadic<T>'
+  ]
+});
+
+// both
+genCurried({
+  base: [
+    ['T'],
+    {
+      pred1: 'Pred<T>',
+      pred2: 'Pred<T>',
+    },
+    'Pred<T>',
+  ]
+});
+
+// call
+genCurried({
+  base: [
+    ['T'],
+    {
+      fn: 'Variadic<T>',
+      '...args': 'any[]',
+    },
+    'T',
+  ]
+});
+
+// chain
+genCurried({
+  'list version': [
+    ['T', 'U'],
+    {
+      fn: '(n: T) => U[]',
+      list: 'List<T>',
+    },
+    'U[]',
+  ],
+  'generic chain version': [
+    ['T', 'U'],
+    {
+      fn: '(n: T) => Chain<U>',
+      list: 'Chain<T>',
+    },
+    'Chain<U>',
+  ],
+  'function argument': [
+    ['T', 'U', 'V'],
+    {
+      fn: '(v: V) => (list: Chain<T>) => Chain<U>',
+      monad: '(chain: Chain<T>) => V'
+    },
+    '(list: Chain<T>) => Chain<U>',
+  ]
+});
+
+// clamp
+genCurried({
+  base: [
+    ['T'],
+    {
+      min: 'T',
+      max: 'T',
+      value: 'T',
+    },
+    'T',
+  ]
+});
+
+// clone
+genCurried({
+  'Objects': [
+    ['T'],
+    {
+      value: 'T'
+    },
+    'T'
+  ],
+  'Arrays': {
+    ['T'],
+    {
+      value: 'List<T>',
+    },
+    'T[]',
+  }
+});
+
+// comparator
+genCurried({
+  base: [
+    ['T'],
+    {
+      pred: '(a: T, b: T) => boolean'
+    },
+    '(x: T, y: T) => number'
+  ]
+});
+
+// complement
+genCurried({
+  base: [
+    ['T'],
+    {
+      pred: 'Variadic<boolean>',
+    },
+    'Variadic<boolean>',
+  ]
+});
+
+// compose
+
+// composeK
+
+// composeP
+
+// concat
+genCurried({
+  base: [
+    ['T extends List<any>'],
+    {
+      list1: 'T',
+      list2: 'T',
+    },
+    'T',
+  ]
+});
+
+// cond
+genCurried({
+  base: [
+    ['T', 'U'],
+    {
+      fns: '[Pred<T>, (v: T) => U][]',
+    },
+    '(v: T) => U'
+  ]
+});
+
+// construct
+genCurried({
+  base: [
+    [],
+    {
+      fn: 'Function',
+    },
+    'Function'
+  ]
+});
+
+// constructN
+genCurried({
+  base: [
+    [],
+    {
+      n: 'number',
+      fn: 'Function',
+    },
+    'Function',
+  ]
+});
+
+// contains
+genCurried({
+  base: [
+    [],
+    {
+      a: 'string',
+      list: 'string',
+    },
+    'boolean',
+  ]
+  generics: [
+    ['T', 'R extends List<T>'],
+    {
+      a: 'T',
+      list: 'R',
+    },
+    'boolean',
+  ]
+});
+
+// converge
+genCurried({
+  base: [
+    ['T'],
+    {
+      after: 'Variadic<T>',
+      fns: 'List<Variadic<any>>',
+    },
+    'Variadic<T>',
+  ]
+});
+
+// countBy
+genCurried({
+  base: [
+    ['T'],
+    {
+      fn: '(a: T) => Prop',
+      list: 'List<T>',
+    },
+    'Obj<number>',
+  ]
+});
+
+// curry
+
+// curryN
+
+// dec
+genCurried({
+  base: [
+    [],
+    {
+      n: 'number',
+    },
+    'number'
+  ]
+});
+
+// defaultTo
+genCurried({
+  base: [
+    ['T', 'U'],
+    {
+      a: 'T',
+      b: 'U',
+    },
+    'T|U',
+  ]
+});
+
+// descend
+genCurried({
+  base: [
+    ['T', 'V extends Ord'],
+    {
+      comparator: '(val: T) => V',
+      a: 'T',
+      b: 'T',
+    },
+    'number'
+  ]
+});
+
+// differenceWith
+genCurried({
+  base: [
+    ['T'],
+    {
+      pred: '(a: T, b: T) => boolean',
+      list1: 'List<T>',
+      list2: 'List<T>',
+    },
+    'T[]'
+  ]
+});
+
+// dissoc
+genCurried({
+  base: [
+    ['T'],
+    {
+      prop: 'keyof T',
+      obj: 'T'
+    },
+    'T'
+  ]
+  'struct': [
+    ['T'],
+    {
+      prop: 'Prop',
+      obj: 'Struct<any>'
+    },
+    'T'
+  ]
+});
+
+// dissocPath
+genCurried({
+  base: [
+    ['T'],
+    {
+      path: 'Path',
+      obj: 'Struct<any>',
+    },
+    'T'
+  ]
+});
+
+// divide
+genCurried({
+  base: [
+    [],
+    {
+      a: 'number',
+      b: 'number',
+    },
+    'number'
+  ]
+});
+
+// drop
+genCurried({
+  base: [
+    ['T extends List<any>'],
+    {
+      n: 'number',
+      xs: 'T'
+    },
+    'T'
+  ]
+});
+
+// dropLast
+genCurried({
+  base: [
+    ['T extends List<any>'],
+    {
+      n: 'number',
+      xs: 'T',
+    },
+    'T'
+  ]
+});
+
+// dropLastWhile
+genCurried({
+  base: [
+    ['T', 'R extends List<T>'],
+    {
+      pred: 'Pred<T>',
+      list: 'R'
+    },
+    'T[]'
+  ]
+});
+
+// dropWhile
+genCurried({
+  base: [
+    ['T', 'R extends List<T>'],
+    {
+      pred: 'Pred<T>',
+      list: 'R'
+    },
+    'T[]'
+  ]
+});
+
+// either
+genCurried({
+  base: [
+    ['T'],
+    {
+      pred1: 'Pred<T>'
+      pred2: 'Pred<T>',
+    },
+    'Pred<T>'
+  ]
+});
+
+// empty
+genCurried({
+  base: [
+    ['T'],
+    {
+      x: 'T',
+    },
+    'T'
+  ]
+});
+
+// eqBy
+genCurried({
+  base: [
+    ['T'],
+    {
+      fn: '(a: T) => T',
+      a: 'T',
+      b: 'T',
+    },
+    'boolean'
+  ]
+});
+
+// eqProps
+genCurried({
+  base: [
+    ['T', 'U'],
+    {
+      prop: 'Prop',
+      obj1: 'T',
+      obj2: 'U'
+    },
+    'boolean'
+  ],
+  'less generics': [
+    [],
+    {
+      prop: 'Prop',
+      obj1: 'any',
+      obj2: 'any',
+    },
+    'boolean'
+  ]
+});
+
+// equals
+genCurried({
+  base: [
+    ['T'],
+    {
+      a: 'T',
+      b: 'T',
+    },
+    'boolean'
+  ]
+});
+
+// evolve
+genCurried({
+  base: [
+    ['V'],
+    {
+      transformations: 'NestedObj<(v: any) => any>',
+      obj: 'V',
+    },
+    'V'
+  ],
+  'no inference': [
+    [],
+    {
+      transformations: 'Obj<Function>',
+      obj: 'any',
+    },
+    'T'
+  ]
+});
+
+// F
+
+// filter
+genCurried({
+  base: [
+    ['T'],
+    {
+      pred: 'Pred<T>',
+      list: 'List<T>',
+    },
+    'T[]'
+  ]
+  'functor to functor': [
+    ['T'],
+    {
+      pred: 'Pred<T>',
+      list: 'Functor<T>',
+    },
+    'Functor[]'
+  ],
+  'functor to array': [
+    ['T'],
+    {
+      pred: 'Pred<T>',
+      list: 'Functor<T>',
+    },
+    'T[]'
+  ],
+  'object': [
+    ['T', 'U extends Obj<T>'],
+    {
+      pred: 'Pred<T>',
+      obj: 'U',
+    },
+    'Partial<U>'
+  ]
+});
+
+// find
+genCurried({
+  base: [
+    ['T'],
+    {
+      fn: '(a: T) => boolean',
+      list: 'List<T>'
+    },
+    'T'
+  ]
+});
+
+// findIndex
+genCurried({
+  base: [
+    ['T'],
+    {
+      fn: '(a: T) => boolean',
+      list: 'List<T>',
+    },
+    'number'
+  ]
+});
+
+// findLast
+genCurried({
+  base: [
+    ['T'],
+    {
+      fn: '(a: T) => boolean',
+      list: 'List<T>',
+    },
+    'T'
+  ]
+});
+
+// findLastIndex
+genCurried({
+  base: [
+    ['T'],
+    {
+      fn: '(a: T) => boolean',
+      list: 'List<T>',
+    },
+    'number'
+  ]
+});
+
+// flatten
+genCurried({
+  base: [
+    ['T'],
+    {
+      x: 'NestedArray<T>'
+    },
+    'T[]'
+  ]
+});
+
+// flip
+genCurried({
+  base: [
+    ['T', 'U', 'TResult'],
+    {
+      fn: '(arg0: T, arg1: U) => TResult'
+    },
+    '(arg1:U, arg0?:T) => TResult'
+  ]
+  'rest arguments': [
+    ['T', 'U', 'Rest', 'TResult'],
+    {
+      fn: '(arg0: T, arg1: U, ...args: Rest[]) => TResult'
+    },
+    '(arg1: U, arg0?: T, ...args: Rest[]) => TResult'
+  ]
+});
+
+// forEach
+genCurried({
+  base: [
+    ['T'],
+    {
+      fn: '(x: T) => void',
+      list: 'List<T>'
+    },
+    'T[]'
+  ]
+});
+
+// forEachObjIndexed
+genCurried({
+  base: [
+    ['T', 'Inp extends Struct<T>'],
+    {
+      fn: '(val: T, key: string, obj?: Inp) => void',
+      o: 'Inp',
+    },
+    'Inp'
+  ]
+});
+
+// fromPairs
+genCurried({
+  base: [
+    ['V'],
+    {
+      pairs: 'List<KeyValuePair<Prop, V>>',
+    },
+    'Obj<V>'
+  ]
+});
+
+// groupBy
+genCurried({
+  base: [
+    ['T'],
+    {
+      fn: '(a: T) => prop',
+      list: 'List<T>',
+    },
+    'Obj<T[]>'
+  ]
+});
+
+// groupWith
+genCurried({
+  base: [
+    ['T'],
+    {
+      fn: '(a: T) => Prop',
+      list: 'List<T>',
+    },
+    'Obj<T[]>'
+  ]
+});
+
+// gt
+genCurried({
+  base: [
+    [],
+    {
+      a: 'number',
+      b: 'number',
+    },
+    'boolean'
+  ]
+});
+
+// gte
+genCurried({
+  base: [
+    [],
+    {
+      a: 'number',
+      b: 'number',
+    },
+    'boolean'
+  ]
+});
+
+// has
+genCurried({
+  base: [
+    [],
+    {
+      s: 'Prop',
+      obj: 'Struct<any>',
+    },
+    'boolean'
+  ]
+});
+
+// hasIn
+genCurried({
+  base: [
+    [],
+    {
+      s: 'Prop',
+      obj: 'Struct<any>',
+    },
+    'boolean'
+  ]
+});
+
+// head
+
+// identical
+genCurried({
+  base: [
+    ['T'],
+    {
+      a: 'T',
+      b: 'T',
+    },
+    'boolean'
+  ]
+});
+
+// identity
+
+// ifElse
+genCurried({
+  base: [
+    ['T', 'U', 'V'],
+    {
+      fn: 'Pred<T>',
+      onTrue: '(v: T) => U',
+      onFalse: '(v: T) => V'
+    },
+    '(v: T) => U|V'
+  ]
+});
+
+// inc
+
+// indexBy
+genCurried({
+  base: [
+    ['T'],
+    {
+      fn: '(a: T) => Prop',
+      list: 'List<T>',
+    },
+    'Obj<T>'
+  ]
+});
+
+// indexOf
+genCurried({
+  base: [
+    ['T'],
+    {
+      target: 'T',
+      list: 'List<T>',
+    },
+    'number'
+  ]
+});
+
+// init
+
+// insert
+genCurried({
+  base: [
+    ['T'],
+    {
+      index: 'number',
+      elt: 'T',
+      list: 'List<T>',
+    },
+    'T[]'
+  ]
+});
+
+// insertAll
+genCurried({
+  base: [
+    ['T', 'U'],
+    {
+      index: 'number',
+      elts: 'List<T>',
+      list: 'List<U>',
+    },
+    'Array<T|U>'
+  ]
+});
+
+// intersection
+genCurried({
+  base: [
+    ['T', 'U'],
+    {
+      list1: 'List<T>',
+      list2: 'List<U>',
+    },
+    'Array<T|U>'
+  ]
+});
+
+// intersectionWith
+genCurried({
+  base: [
+    ['T'],
+    {
+      pred: '(a: T, b: T) => boolean',
+      list1: 'List<T>',
+      list2: 'List<T>',
+    },
+    'T[]'
+  ]
+});
+
+// intersperse
+genCurried({
+  base: [
+    ['T'],
+    {
+      separator: 'T',
+      list: 'List<T>',
+    },
+    'T[]'
+  ]
+});
+
+// into
+genCurried({
+  base: [
+    ['T', 'U', 'V extends AccOpts<T, U>'],
+    {
+      acc: 'V',
+      xf: '(list: List<T>) => U',
+      list: 'List<T>',
+    },
+    'U'
+  ]
+});
+
+// invert
+
+// invoker
+genCurried({
+  base: [
+    ['T', 'R'],
+    {
+      len: 'number',
+      name: 'Prop',
+      obj: 'T',
+    },
+    'R'
+  ]
+});
+
+// is
+genCurried({
+  base: [
+    ['T'],
+    {
+      ctor: 'Type<T>',
+      val: 'any',
+    },
+    'val is T'
+  ]
+});
+
+// isArrayLike
+
+// isEmpty
+
+// isNaN
+
+// isNil
+
+// join
+genCurried({
+  base: [
+    [],
+    {
+      x: 'Prop',
+      xs: 'Array<any>',
+    },
+    'string'
+  ]
+});
+
+// juxt
+genCurried({
+  base: [
+    ['T', 'U'],
+    {
+      fns: '{(...args: T[]): U}[]'
+    },
+    '(...args: T[]) => U[]'
+  ]
+});
+
+// keys
+
+// keysIn
+
+// last
+
+// lastIndexOf
+genCurried({
+  base: [
+    ['T'],
+    {
+      target: 'T',
+      list: 'List<T>',
+    },
+    'number'
+  ]
+});
+
+// length
+
+// lens
+genCurried({
+  base: [
+    ['V', 'U extends Struct<any>'],
+    {
+      getter: '(s: U) => V',
+      setter: '(a: V, s: U) => U',
+    },
+    'ManualLens<V>'
+  ],
+  'allows setter to change value type': [
+    ['T', 'U', 'V'],
+    {
+      getter: '(s: T) => U',
+      setter: '(a: U, s: T) => V'
+    },
+    'Lens<T, U>'
+  ]
+});
+
+// lensIndex
+
+// lensPath
+
+// lift --
+
+// liftN
+
+// lt
+genCurried({
+  base: [
+    [],
+    {
+      a: 'number',
+      b: 'number',
+    },
+    'boolean'
+  ]
+});
+
+// lte
+genCurried({
+  base: [
+    [],
+    {
+      a: 'number',
+      b: 'number',
+    },
+    'boolean'
+  ]
+});
+
+// map
+genCurried({
+  base: [
+    ['T', 'U'],
+    {
+      fn: '(x: T) => U',
+      list: 'List<T>',
+    },
+    'U[]'
+  ],
+  'object: keyof version': [
+    ['T', 'U', 'M extends Obj<T>'],
+    {
+      fn: '(value: T) => U',
+      obj: 'M',
+    },
+    '{[K in keyof M]: U}'
+  ],
+  'object: Record version': [
+    ['T', 'U', 'K extends string'],
+    {
+      f: '(x: T) => U',
+      obj: 'Record<K, T>',
+    },
+    'Record<K, U>'
+  ],
+  'functor': [
+    ['T', 'U'],
+    {
+      x: '(x: T) => U',
+      obj: 'Functor<T>',
+    },
+    'Functor<U>'
+  ]
+});
+
+// mapAccum
+genCurried({
+  base: [
+    ['T', 'U', 'TResult'],
+    {
+      fn: '(acc: U, value: T) => [U, TResult]',
+      acc: 'U',
+      list: 'List<T>',
+    },
+    '[U, TResult[]]'
+  ]
+});
+
+// mapAccumRight
+genCurried({
+  base: [
+    ['T', 'U', 'TResult'],
+    {
+      fn: '(value: T, acc: U) => [TResult, U]',
+      acc: 'U',
+      list: 'List<T>',
+    },
+    '[TResult[], U]'
+  ]
+});
+
+// mapIndexed
+genCurried({
+  base: [
+    ['T', 'U', 'V'],
+    {
+      fn: '(value: T, acc: U) => [TResult, U]',
+      acc: 'U',
+      list: 'List<T>',
+    },
+    '[TResult[], U]',
+  ]
+});
+
+// mapObjIndexed
+genCurried({
+  base: [
+    ['T', 'V', 'M extends Obj<T>'],
+    {
+      fn: '(value: T, key: string, obj?:M) => V',
+      obj: 'M'
+    },
+    '{[K in keyof M]: V}'
+  ]
+});
+
+// match
+genCurried({
+  base: [
+    [],
+    {
+      regexp: 'RegExp',
+      str: 'string'
+    },
+    'string[]'
+  ]
+});
+
+// mathMod
+genCurried({
+  base: [
+    [],
+    {
+      a: 'number',
+      b: 'number',
+    },
+    'number'
+  ]
+});
+
+// max
+genCurried({
+  base: [
+    ['T extends Ord'],
+    {
+      a: 'T',
+      b: 'T',
+    },
+    'T'
+  ]
+});
+
+// maxBy
+genCurried({
+  base: [
+    ['T'],
+    {
+      keyFn: '(a: T) => Ord',
+      a: 'T',
+      b: 'T',
+    },
+    'T'
+  ]
+});
+
+// mean
+
+// median
+
+// memoize
+
+// merge
+genCurried({
+  base: [
+    ['V1', 'V2', 'T1 extends Struct<V1>', 'T2 extends Struct<V2>'],
+    {
+      a: 'T1',
+      b: 'T2',
+    },
+    'T1 & T2'
+  ]
+});
+
+// mergeAll
+genCurried({
+  base: [
+    ['T'],
+    {
+      list: 'List<any>',
+    },
+    'T'
+  ]
+});
+
+// mergeWith
+genCurried({
+  base: [
+    ['U', 'V'],
+    {
+      fn: '(x: any, z: any) => any',
+      a: 'U',
+      b: 'V',
+    },
+    'U & V'
+  ]
+});
+
+// minBy
+genCurried({
+  base: [
+    ['T'],
+    {
+      keyFn: '(a: T) => Ord',
+      a: 'T',
+      b: 'T'
+    },
+    'T'
+  ]
+});
+
+// over
+genCurried({
+  'Functor version': [
+    ['V', 'T extends Functor<V>'],
+    {
+      lens: 'Lens<T, V>|ManualLens<V>|UnknownLens',
+      fn: '(v: V) => V',
+      value: 'T',
+    },
+    'T'
+  ],
+  'Functor version applied to array': [
+    ['V', 'T extends List<V>'],
+    {
+      lens: 'Lens<T, V>|ManualLens<V>|UnknownLens',
+      fn: '(v: V) => V',
+      value: 'T',
+    },
+    'V[]'
+  ],
+  'unbound value': [
+    ['T', 'V'],
+    {
+      lens: 'Lens<T, V>|ManualLens|UnknownLens',
+      fn: '(v: V) => V',
+      value: 'T',
+    },
+    'T'
+  ]
+});
+
+// pathOr
+genCurried({
+  base: [
+    ['T'],
+    {
+      d: 'T',
+      p: 'Path',
+      obj: 'Struct<any>',
+    },
+    'T|any'
+  ]
+});
+
+// pathSatisfies
+genCurried({
+  base: [
+    ['T'],
+    {
+      fn: 'Pred<T>',
+      p: 'Path',
+      obj: 'any',
+    },
+    'boolean'
+  ]
+});
+
+// propEq
+genCurried({
+  base: [
+    ['T extends Struct<any>'],
+    {
+      name: 'Prop',
+      val: 'any',
+      obj: 'T',
+    },
+    'boolean'
+  ]
+});
+
+// propOr
+genCurried({
+  base: [
+    ['T', 'U', 'K extends keyof U'],
+    {
+      val: 'T',
+      p: 'K',
+      obj: 'U'
+    },
+    'U[K] | T'
+  ]
+});
+
+// propStatisfies
+genCurried({
+  'Record (curry-friendly)': [
+    ['V', 'K extends string', 'U extends Record<K, V>'],
+    {
+      pred: 'Pred<V>',
+      name: 'K',
+      obj: 'U',
+    },
+    'boolean'
+  ],
+  'keyof, info too late on currying': [
+    ['T', 'U'],
+    {
+      pred: 'Pred<T>',
+      name: 'Prop',
+      obj: 'U'
+    },
+    'boolean'
+  ]
+});
+
+// reduce
+genCurried({
+  base: [
+    ['T', 'TResult', 'R extends List<T>'],
+    {
+      fn: '(acc: TResult, elem: T, idx: number, list: R) => TResult|Reduced',
+      acc: 'TResult',
+      list: 'R',
+    },
+    'TResult'
+  ]
+});
+
+// reduceBy
+genCurried({
+  base: [
+    ['T', 'TResult', 'R extends List<T>'],
+    {
+      valueFn: '(acc: TResult, elem: T, idx: nuber, list: R) => TResult',
+      acc: 'TResult|any',
+      keyFn: '(elem: T) => string',
+      list: 'R',
+    },
+    'TResult'
+  ]
+});
+
+// reduceRight
+genCurried({
+  base: [
+    ['T', 'TResult'],
+    {
+      fn: '(elem: T, acc: TResult) => TResult|Reduced',
+      acc: 'TResult|any',
+      list: 'List<T>',
+    },
+    'TResult'
+  ]
+});
+
+// reduceWhile
+genCurried({
+  base: [
+    ['T', 'TResult'],
+    {
+      pred: '(acc: TResult, elem: T) => boolean',
+      fn: '(acc: TResult, elem: T) => TResult|Reduced',
+      acc: 'TResult',
+      list: 'List<T>',
+    },
+    'TResult'
+  ]
+});
+
+// remove
+genCurried({
+  base: [
+    ['T'],
+    {
+      start: 'number',
+      count: 'number',
+      list: 'List<T>',
+    },
+    'T[]'
+  ]
+});
+
+// replace
+genCurried({
+  base: [
+    [],
+    {
+      pattern: 'RegExp|Prop',
+      replacement: 'Prop',
+      str: 'string',
+    },
+    'string'
+  ]
+});
+
+// scan
+genCurried({
+  base: [
+    ['T', 'TResult'],
+    {
+      fn: '(acc: TResult, elem: T) => TResult|Reduced',
+      acc: 'TResult',
+      list: 'List<T>'
+    },
+    'TResult[]'
+  ]
+});
+
+// set
+genCurried({
+  base: [
+    ['T', 'U'],
+    {
+      lens: 'Lens<T, U>',
+      a: 'U',
+      obj: 'T'
+    },
+    'T'
+  ]
+});
+
+// slice
+genCurried({
+  base: [
+    ['T extends List<any>'],
+    {
+      a: 'number',
+      b: 'number',
+      list: 'T',
+    },
+    'T'
+  ]
+});
+
+// symmetricDifferenceWith
+genCurried({
+  base: [
+    ['T'],
+    {
+      pred: '(a: T, b: T) => boolean',
+      list1: 'List<T>',
+      list2: 'List<T>',
+    },
+    'T[]'
+  ]
+});
+
+// transduce
+genCurried({
+  base: [
+    ['T', 'U'],
+    {
+      xf: '(arg: List<T>) => List<T>',
+      fn: '(acc: List<U>, val:U) => List<U>',
+      acc: 'List<T>',
+      list: 'List<T>'
+    },
+    'U'
+  ]
+});
+
+// traverse
+genCurried({
+  base: [
+    ['T', 'U'],
+    {
+      ap: '(v: T) => Applicative<T>',
+      fn: '(v: T) => Applicative<U>',
+      traversable: 'List<T>',
+    },
+    'Applicative<Array<U>>'
+  ],
+  'general ADT case': [
+    ['T', 'U'],
+    {
+      ap: '(v: T) => Applicative<T>',
+      fn: '(v: T) => Applicative<U>',
+      traversable: 'List<T>',
+    },
+    'Applicative<Traversable<U>>'
+  ]
+});
+
+// unionWith
+genCurried({
+  base: [
+    ['T'],
+    {
+      pred: '(a: T, b: T) => boolean',
+      list1: 'List<T>',
+      list2: 'List<T>',
+    },
+    'T[]'
+  ]
+});
+
+// until
+genCurried({
+  base: [
+    ['T', 'U'],
+    {
+      pred: 'Pred<T>',
+      fn: '(val: T) => U',
+      init: 'U',
+    },
+    'U'
+  ]
+});
+
+// update
+genCurried({
+  base: [
+    ['T'],
+    {
+      index: 'number',
+      value: 'T',
+      list: 'List<T>'
+    },
+    'T[]'
+  ]
+});
+
+// when
+genCurried({
+  base: [
+    ['T', 'U'],
+    {
+      pred: 'Pred<T>',
+      whenTrueFn: '(a: T) => U',
+      obj: 'T',
+    },
+    'U'
+  ]
+});
+
+


### PR DESCRIPTION
Adds scripts to replace type signatures using codegen as an alternative to the `CurriedFunction` interfaces.
