### PR TITLE
propIs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2491,44 +2491,9 @@ declare namespace R {
         /**
          * Returns true if the specified object property is of the given type; false otherwise.
          */
-
-        // Record
-        propIs<T extends Function, K extends string, V, U extends Record<K,V>>(type: T, name: K, obj: U): obj is (U & Record<K, T>);
-        propIs<T extends Function, K extends string>(type: T, name: K): <V, U extends Record<K,V>>(obj: U) => obj is (U & Record<K, T>);
-        // propIs<T extends Function>(type: T): {
-        //     <K extends string, V, U extends Record<K,V>>(name: K, obj: U): obj is (U & Record<K, T>);
-        //     <K extends string>(name: K): <V, U extends Record<K,V>>(obj: U) => obj is (U & Record<K, T>);
-        // }
-        // propIs<T extends Function, K extends string, V, U extends Record<K,V>>: CurriedFunction3<T, K, U, V is (V & Record<K, T>)>; // obj is? name unavailable...
-
-        // inference, fails if name and object are supplied separately
-        propIs<T extends Function, V, K extends keyof V>(type: T, name: K, obj: V): obj is (V & Record<K, T>);
-        // propIs<T extends Function, V, K extends keyof V>(type: T, name: K): (obj: V) => obj is (V & Record<K, T>);  // object info not available in time :(
-        // propIs<T extends Function>(type: T): {
-        //     <V, K extends keyof V>(name: K, obj: V): obj is (V & Record<K, T>);
-        //     <V, K extends keyof V>(name: K): (obj: V) => obj is (V & Record<K, T>);  // object info not available in time :(
-        // }
-        // propIs<T extends Function, V, K extends keyof V>: CurriedFunction3<T, K, V, V is (V & Record<K, T>)>; // obj is? name unavailable...
-
-        // // curry-friendlier fallback
-        // // propIs(type: Function, name: Prop, obj: Struct<any>): boolean;
-        // propIs(type: Function, name: Prop): (obj: Struct<any>) => boolean;
-        // propIs(type: Function): CurriedFunction2<Prop, Struct<any>, boolean>;
-        // // propIs(type: Function): {
-        // //     (name: Prop, obj: Struct<any>): boolean;
-        // //     (name: Prop): (obj: Struct<any>) => boolean;
-        // // }
-        // // propIs: CurriedFunction3<Function, Prop, Struct<any>, boolean>;
-
-        // mixed:
-        propIs<T extends Function>(type: T): {
-            // record
-            <K extends string, V, U extends Record<K,V>>(name: K, obj: U): obj is (U & Record<K, T>);
-            <K extends string>(name: K): <V, U extends Record<K,V>>(obj: U) => obj is (U & Record<K, T>);
-            // keyof
-            <V, K extends keyof V>(name: K, obj: V): obj is (V & Record<K, T>);
-            // <V, K extends keyof V>(name: K): (obj: V) => obj is (V & Record<K, T>);  // object info not available in time :(
-        };
+        propIs(type: Function, name: string, obj: Object): boolean;
+        propIs(type: Function, name: string): CurriedFunction1<Object, boolean>;
+        propIs(type: Function): CurriedFunction2<string, Object, boolean>;
 
         /**
          * If the given, non-null object has an own property with the specified name, returns the value of that property.

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -46,7 +46,7 @@ class F2 {
     R.propIs(Number)('x', {x: 1, y: 2});  // => true // $ExpectType boolean
     R.propIs(Number)('x')({x: 1, y: 2});  // => true // $ExpectType boolean
     R.propIs(Number, 'x', {x: 'foo'});    // => false // $ExpectType boolean
-    R.propIs(Number, 'x', {});            // => false // $ExpectError Argument of type 'x' is not assignable to parameter of type 'never'.`, because 'x' is not in `{}`.
+    R.propIs(Number, 'x', {});            // => false // $ExpectType boolean
 });
 
 // type


### PR DESCRIPTION
I don't understand why all these definitions have been made so complex.

Let's take propIs as an example:
Looking at the ramda source code for propIs (https://github.com/ramda/ramda/blob/v0.23.0/src/propIs.js), the signature is defined as "`Type -> String -> Object -> Boolean`". 

Why the generics? Why the Record? Why not simply return boolean? By making it so complex, restrictions and logic are added which the actual ramda library should be able to handle itself.

`R.propIs(Number, 'x', {});` is a valid call returnning false, no error should be expected (https://github.com/ramda/ramda/blob/v0.23.0/test/propIs.js).

Maybe I see it too simple, but what is currently in this definition-file is way to complex.
