### PR TITLE
Correct defaultTo, head, path, nth, last

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2509,7 +2509,7 @@ declare namespace R {
           <V, T extends Record<K, V>>(obj: T): V;
           // manually typed
           <T>(obj: Struct<any>): T;
-        }
+        };
 
         /**
          * Determines whether the given property of an object has a specific

--- a/index.d.ts
+++ b/index.d.ts
@@ -2069,14 +2069,14 @@ declare namespace R {
         path<T1 extends string, T2 extends string, T3 extends string, T4 extends string, T5 extends string, T6 extends string, T7 extends string, T8 extends string, T9 extends string, TResult>(path: [T1, T2, T3, T4, T5, T6, T7, T8, T9], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: {[K4 in T4]: {[K5 in T5]: {[K6 in T6]: {[K7 in T7]: {[K8 in T8]: {[K9 in T9]: TResult}}}}}}}}}): TResult;
 
         // Record-based
-        path<K1 extends string, K2 extends string, TResult>(path: [K1, K2], obj: Record<K1,Record<K2,TResult>>): TResult | undefined;
-        path<K1 extends string, K2 extends string, K3 extends string, TResult>(path: [K1, K2, K3], obj: Record<K1,Record<K2,Record<K3,TResult>>>): TResult | undefined;
-        path<K1 extends string, K2 extends string, K3 extends string, K4 extends string, TResult>(path: [K1, K2, K3, K4], obj: Record<K1,Record<K2,Record<K3,Record<K4,TResult>>>>): TResult | undefined;
-        path<K1 extends string, K2 extends string, K3 extends string, K4 extends string, K5 extends string, TResult>(path: [K1, K2, K3, K4, K5], obj: Record<K1,Record<K2,Record<K3,Record<K4,Record<K5,TResult>>>>>): TResult | undefined;
-        path<K1 extends string, K2 extends string, K3 extends string, K4 extends string, K5 extends string, K6 extends string, TResult>(path: [K1, K2, K3, K4, K5, K6], obj: Record<K1,Record<K2,Record<K3,Record<K4,Record<K5,Record<K6,TResult>>>>>>): TResult | undefined;
-        path<K1 extends string, K2 extends string, K3 extends string, K4 extends string, K5 extends string, K6 extends string, K7 extends string, TResult>(path: [K1, K2, K3, K4, K5, K6, K7], obj: Record<K1,Record<K2,Record<K3,Record<K4,Record<K5,Record<K6,Record<K7,TResult>>>>>>>): TResult | undefined;
-        path<K1 extends string, K2 extends string, K3 extends string, K4 extends string, K5 extends string, K6 extends string, K7 extends string, K8 extends string, TResult>(path: [K1, K2, K3, K4, K5, K6, K7, K8], obj: Record<K1,Record<K2,Record<K3,Record<K4,Record<K5,Record<K6,Record<K7,Record<K8,TResult>>>>>>>>): TResult | undefined;
-        path<K1 extends string, K2 extends string, K3 extends string, K4 extends string, K5 extends string, K6 extends string, K7 extends string, K8 extends string, K9 extends string, TResult>(path: [K1, K2, K3, K4, K5, K6, K7, K8, K9], obj: Record<K1,Record<K2,Record<K3,Record<K4,Record<K5,Record<K6,Record<K7,Record<K8,Record<K9,TResult>>>>>>>>>): TResult | undefined;
+        path<K1 extends string, K2 extends string, TResult>(path: [K1, K2], obj: Record<K1,Record<K2,TResult>>): TResult;
+        path<K1 extends string, K2 extends string, K3 extends string, TResult>(path: [K1, K2, K3], obj: Record<K1,Record<K2,Record<K3,TResult>>>): TResult;
+        path<K1 extends string, K2 extends string, K3 extends string, K4 extends string, TResult>(path: [K1, K2, K3, K4], obj: Record<K1,Record<K2,Record<K3,Record<K4,TResult>>>>): TResult;
+        path<K1 extends string, K2 extends string, K3 extends string, K4 extends string, K5 extends string, TResult>(path: [K1, K2, K3, K4, K5], obj: Record<K1,Record<K2,Record<K3,Record<K4,Record<K5,TResult>>>>>): TResult;
+        path<K1 extends string, K2 extends string, K3 extends string, K4 extends string, K5 extends string, K6 extends string, TResult>(path: [K1, K2, K3, K4, K5, K6], obj: Record<K1,Record<K2,Record<K3,Record<K4,Record<K5,Record<K6,TResult>>>>>>): TResult;
+        path<K1 extends string, K2 extends string, K3 extends string, K4 extends string, K5 extends string, K6 extends string, K7 extends string, TResult>(path: [K1, K2, K3, K4, K5, K6, K7], obj: Record<K1,Record<K2,Record<K3,Record<K4,Record<K5,Record<K6,Record<K7,TResult>>>>>>>): TResult;
+        path<K1 extends string, K2 extends string, K3 extends string, K4 extends string, K5 extends string, K6 extends string, K7 extends string, K8 extends string, TResult>(path: [K1, K2, K3, K4, K5, K6, K7, K8], obj: Record<K1,Record<K2,Record<K3,Record<K4,Record<K5,Record<K6,Record<K7,Record<K8,TResult>>>>>>>>): TResult;
+        path<K1 extends string, K2 extends string, K3 extends string, K4 extends string, K5 extends string, K6 extends string, K7 extends string, K8 extends string, K9 extends string, TResult>(path: [K1, K2, K3, K4, K5, K6, K7, K8, K9], obj: Record<K1,Record<K2,Record<K3,Record<K4,Record<K5,Record<K6,Record<K7,Record<K8,Record<K9,TResult>>>>>>>>>): TResult;
 
         // for each path length list all combinations of objects and homogeneous arrays... tuples not supported yet.
 
@@ -2505,7 +2505,7 @@ declare namespace R {
 
         // mixed for currying:
         prop<K extends string>(p: K): {
-          // Record versionq
+          // Record version
           <V, T extends Record<K, V>>(obj: T): V;
           // manually typed
           <T>(obj: Struct<any>): T;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2080,20 +2080,20 @@ declare namespace R {
 
         // for each path length list all combinations of objects and homogeneous arrays... tuples not supported yet.
 
-        path<T1 extends string, TResult>(path: [T1], obj: {[K1 in T1]: TResult}): TResult | undefined;
-        path<T1 extends number, TResult>(path: [T1], obj: TResult[]): TResult | undefined;
-        path<T1 extends string, T2 extends string, TResult>(path: [T1, T2], obj: {[K1 in T1]: {[K2 in T2]: TResult}}): TResult | undefined;
-        path<T1 extends string, T2 extends number, TResult>(path: [T1, T2], obj: {[K1 in T1]: TResult[]}): TResult | undefined;
-        path<T1 extends number, T2 extends string, TResult>(path: [T1, T2], obj: {[K2 in T2]: TResult}[]): TResult | undefined;
-        path<T1 extends number, T2 extends number, TResult>(path: [T1, T2], obj: TResult[][]): TResult | undefined;
-        path<T1 extends string, T2 extends string, T3 extends string, TResult>(path: [T1, T2, T3], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: TResult}}}): TResult | undefined;
-        path<T1 extends string, T2 extends string, T3 extends number, TResult>(path: [T1, T2, T3], obj: {[K1 in T1]: {[K2 in T2]: TResult[]}}): TResult | undefined;
-        path<T1 extends string, T2 extends number, T3 extends string, TResult>(path: [T1, T2, T3], obj: {[K1 in T1]: {[K3 in T3]: TResult}[]}): TResult | undefined;
-        path<T1 extends string, T2 extends number, T3 extends number, TResult>(path: [T1, T2, T3], obj: {[K1 in T1]: TResult[][]}): TResult | undefined;
-        path<T1 extends number, T2 extends string, T3 extends string, TResult>(path: [T1, T2, T3], obj: {[K2 in T2]: {[K3 in T3]: TResult}}[]): TResult | undefined;
-        path<T1 extends number, T2 extends string, T3 extends number, TResult>(path: [T1, T2, T3], obj: {[K2 in T2]: TResult[]}[]): TResult | undefined;
-        path<T1 extends number, T2 extends number, T3 extends string, TResult>(path: [T1, T2, T3], obj: {[K3 in T3]: TResult}[][]): TResult | undefined;
-        path<T1 extends number, T2 extends number, T3 extends number, TResult>(path: [T1, T2, T3], obj: TResult[][][]): TResult | undefined;
+        path<T1 extends string, TResult>(path: [T1], obj: {[K1 in T1]: TResult}): TResult;
+        path<T1 extends number, TResult>(path: [T1], obj: TResult[]): TResult;
+        path<T1 extends string, T2 extends string, TResult>(path: [T1, T2], obj: {[K1 in T1]: {[K2 in T2]: TResult}}): TResult;
+        path<T1 extends string, T2 extends number, TResult>(path: [T1, T2], obj: {[K1 in T1]: TResult[]}): TResult;
+        path<T1 extends number, T2 extends string, TResult>(path: [T1, T2], obj: {[K2 in T2]: TResult}[]): TResult;
+        path<T1 extends number, T2 extends number, TResult>(path: [T1, T2], obj: TResult[][]): TResult;
+        path<T1 extends string, T2 extends string, T3 extends string, TResult>(path: [T1, T2, T3], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: TResult}}}): TResult;
+        path<T1 extends string, T2 extends string, T3 extends number, TResult>(path: [T1, T2, T3], obj: {[K1 in T1]: {[K2 in T2]: TResult[]}}): TResult;
+        path<T1 extends string, T2 extends number, T3 extends string, TResult>(path: [T1, T2, T3], obj: {[K1 in T1]: {[K3 in T3]: TResult}[]}): TResult;
+        path<T1 extends string, T2 extends number, T3 extends number, TResult>(path: [T1, T2, T3], obj: {[K1 in T1]: TResult[][]}): TResult;
+        path<T1 extends number, T2 extends string, T3 extends string, TResult>(path: [T1, T2, T3], obj: {[K2 in T2]: {[K3 in T3]: TResult}}[]): TResult;
+        path<T1 extends number, T2 extends string, T3 extends number, TResult>(path: [T1, T2, T3], obj: {[K2 in T2]: TResult[]}[]): TResult;
+        path<T1 extends number, T2 extends number, T3 extends string, TResult>(path: [T1, T2, T3], obj: {[K3 in T3]: TResult}[][]): TResult;
+        path<T1 extends number, T2 extends number, T3 extends number, TResult>(path: [T1, T2, T3], obj: TResult[][][]): TResult;
         // path<T1 extends string, T2 extends string, T3 extends string, T4 extends string, TResult>(path: [T1, T2, T3, T4], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: {[K4 in T4]: TResult}}}}): TResult;
         // path<T1 extends string, T2 extends string, T3 extends string, T4 extends number, TResult>(path: [T1, T2, T3, T4], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: TResult[]}}}): TResult;
         // path<T1 extends string, T2 extends string, T3 extends number, T4 extends string, TResult>(path: [T1, T2, T3, T4], obj: {[K1 in T1]: {[K2 in T2]: {[K4 in T4]: TResult}[]}}): TResult;
@@ -2505,7 +2505,7 @@ declare namespace R {
 
         // mixed for currying:
         prop<K extends string>(p: K): {
-          // Record version
+          // Record versionq
           <V, T extends Record<K, V>>(obj: T): V;
           // manually typed
           <T>(obj: Struct<any>): T;

--- a/index.d.ts
+++ b/index.d.ts
@@ -681,7 +681,6 @@ declare namespace R {
         contains<T, U, R extends List<T|U>>(a: T, list: R): boolean;
         contains<T>(a: T): <U, R extends List<T|U>>(list: R) => boolean;
         // contains<T, U, R extends List<T|U>>: CurriedFunction2<T, R, boolean>;
-  
         /**
          * Accepts a converging function and a list of branching functions and returns a new
          * function. When invoked, this new function is applied to some arguments, each branching
@@ -733,8 +732,8 @@ declare namespace R {
          * Returns the second argument if it is not null or undefined. If it is null or undefined, the
          * first (default) argument is returned.
          */
-        defaultTo<T,U>(a: T, b: U): T|U;
-        defaultTo<T>(a: T): <U>(b: U) => T|U;
+        defaultTo<T,U>(a: T, b: U | null | undefined): T|U;
+        defaultTo<T>(a: T): <U>(b: U | null | undefined) => T|U;
         // defaultTo<T,U>: CurriedFunction2<T, U, T|U>;
 
         /**
@@ -1151,11 +1150,11 @@ declare namespace R {
          * In some libraries this function is named `first`.
          */
         head<T extends List<any>>(list: T): T[0];
-        head(list: string): string;
+        head(list: string): string | undefined;
         // tuple attempts; it doesn't like these.
-        head<T>(list: [T]): T;
-        head<T0, T1>(list: [T0, T1]): T0;
-        head<T0, T1, T2>(list: [T0, T1, T2]): T0;
+        head<T>(list: [T]): T | undefined;
+        head<T0, T1>(list: [T0, T1]): T0 | undefined;
+        head<T0, T1, T2>(list: [T0, T1, T2]): T0 | undefined;
 
         /**
          * Returns true if its arguments are identical, false otherwise. Values are identical if they reference the
@@ -1438,7 +1437,7 @@ declare namespace R {
         /**
          * Returns the last element from a list.
          */
-        last<T, R extends List<T>>(list: R): T;
+        last<T, R extends List<T>>(list: R): T | undefined;
 
         /**
          * Returns the position of the last occurrence of an item (by strict equality) in
@@ -1454,7 +1453,7 @@ declare namespace R {
          */
         length(list: List<any>): number;
 
-        /**
+        /*
          * Returns a lens for the given getter and setter functions. The getter
          * "gets" the value of the focus; the setter "sets" the value of the focus.
          * The setter should not mutate the data structure.
@@ -1876,8 +1875,8 @@ declare namespace R {
         /**
          * Returns the nth element in a list.
          */
-        nth<T>(n: number, list: List<T>): T;
-        nth(n: number): <T>(list: List<T>) => T;
+        nth<T>(n: number, list: List<T>): T | undefined;
+        nth(n: number): <T>(list: List<T>) => T | undefined;
         // nth<T>: CurriedFunction2<number, List<T>, T>;
 
         /**
@@ -2059,41 +2058,41 @@ declare namespace R {
         // simpler versions, able to deal only with objects, not arrays:
 
         // in-based
-        path<T1 extends string, T2 extends string, TResult>(path: [T1, T2], obj: {[K1 in T1]: {[K2 in T2]: TResult}}): TResult;
-        path<T1 extends string, T2 extends string, T3 extends string, TResult>(path: [T1, T2, T3], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: TResult}}}): TResult;
-        path<T1 extends string, T2 extends string, T3 extends string, T4 extends string, TResult>(path: [T1, T2, T3, T4], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: {[K4 in T4]: TResult}}}}): TResult;
-        path<T1 extends string, T2 extends string, T3 extends string, T4 extends string, T5 extends string, TResult>(path: [T1, T2, T3, T4, T5], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: {[K4 in T4]: {[K5 in T5]: TResult}}}}}): TResult;
-        path<T1 extends string, T2 extends string, T3 extends string, T4 extends string, T5 extends string, T6 extends string, TResult>(path: [T1, T2, T3, T4, T5, T6], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: {[K4 in T4]: {[K5 in T5]: {[K6 in T6]: TResult}}}}}}): TResult;
-        path<T1 extends string, T2 extends string, T3 extends string, T4 extends string, T5 extends string, T6 extends string, T7 extends string, TResult>(path: [T1, T2, T3, T4, T5, T6, T7], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: {[K4 in T4]: {[K5 in T5]: {[K6 in T6]: {[K7 in T7]: TResult}}}}}}}): TResult;
-        path<T1 extends string, T2 extends string, T3 extends string, T4 extends string, T5 extends string, T6 extends string, T7 extends string, T8 extends string, TResult>(path: [T1, T2, T3, T4, T5, T6, T7, T8], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: {[K4 in T4]: {[K5 in T5]: {[K6 in T6]: {[K7 in T7]: {[K8 in T8]: TResult}}}}}}}}): TResult;
-        path<T1 extends string, T2 extends string, T3 extends string, T4 extends string, T5 extends string, T6 extends string, T7 extends string, T8 extends string, T9 extends string, TResult>(path: [T1, T2, T3, T4, T5, T6, T7, T8, T9], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: {[K4 in T4]: {[K5 in T5]: {[K6 in T6]: {[K7 in T7]: {[K8 in T8]: {[K9 in T9]: TResult}}}}}}}}}): TResult;
+        path<T1 extends string, T2 extends string, TResult>(path: [T1, T2], obj: {[K1 in T1]: {[K2 in T2]: TResult}}): TResult | undefined;
+        path<T1 extends string, T2 extends string, T3 extends string, TResult>(path: [T1, T2, T3], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: TResult}}}): TResult | undefined;
+        path<T1 extends string, T2 extends string, T3 extends string, T4 extends string, TResult>(path: [T1, T2, T3, T4], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: {[K4 in T4]: TResult}}}}): TResult | undefined;
+        path<T1 extends string, T2 extends string, T3 extends string, T4 extends string, T5 extends string, TResult>(path: [T1, T2, T3, T4, T5], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: {[K4 in T4]: {[K5 in T5]: TResult}}}}}): TResult | undefined;
+        path<T1 extends string, T2 extends string, T3 extends string, T4 extends string, T5 extends string, T6 extends string, TResult>(path: [T1, T2, T3, T4, T5, T6], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: {[K4 in T4]: {[K5 in T5]: {[K6 in T6]: TResult}}}}}}): TResult | undefined;
+        path<T1 extends string, T2 extends string, T3 extends string, T4 extends string, T5 extends string, T6 extends string, T7 extends string, TResult>(path: [T1, T2, T3, T4, T5, T6, T7], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: {[K4 in T4]: {[K5 in T5]: {[K6 in T6]: {[K7 in T7]: TResult}}}}}}}): TResult | undefined;
+        path<T1 extends string, T2 extends string, T3 extends string, T4 extends string, T5 extends string, T6 extends string, T7 extends string, T8 extends string, TResult>(path: [T1, T2, T3, T4, T5, T6, T7, T8], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: {[K4 in T4]: {[K5 in T5]: {[K6 in T6]: {[K7 in T7]: {[K8 in T8]: TResult}}}}}}}}): TResult | undefined;
+        path<T1 extends string, T2 extends string, T3 extends string, T4 extends string, T5 extends string, T6 extends string, T7 extends string, T8 extends string, T9 extends string, TResult>(path: [T1, T2, T3, T4, T5, T6, T7, T8, T9], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: {[K4 in T4]: {[K5 in T5]: {[K6 in T6]: {[K7 in T7]: {[K8 in T8]: {[K9 in T9]: TResult}}}}}}}}}): TResult | undefined;
 
         // Record-based
-        path<K1 extends string, K2 extends string, TResult>(path: [K1, K2], obj: Record<K1,Record<K2,TResult>>): TResult;
-        path<K1 extends string, K2 extends string, K3 extends string, TResult>(path: [K1, K2, K3], obj: Record<K1,Record<K2,Record<K3,TResult>>>): TResult;
-        path<K1 extends string, K2 extends string, K3 extends string, K4 extends string, TResult>(path: [K1, K2, K3, K4], obj: Record<K1,Record<K2,Record<K3,Record<K4,TResult>>>>): TResult;
-        path<K1 extends string, K2 extends string, K3 extends string, K4 extends string, K5 extends string, TResult>(path: [K1, K2, K3, K4, K5], obj: Record<K1,Record<K2,Record<K3,Record<K4,Record<K5,TResult>>>>>): TResult;
-        path<K1 extends string, K2 extends string, K3 extends string, K4 extends string, K5 extends string, K6 extends string, TResult>(path: [K1, K2, K3, K4, K5, K6], obj: Record<K1,Record<K2,Record<K3,Record<K4,Record<K5,Record<K6,TResult>>>>>>): TResult;
-        path<K1 extends string, K2 extends string, K3 extends string, K4 extends string, K5 extends string, K6 extends string, K7 extends string, TResult>(path: [K1, K2, K3, K4, K5, K6, K7], obj: Record<K1,Record<K2,Record<K3,Record<K4,Record<K5,Record<K6,Record<K7,TResult>>>>>>>): TResult;
-        path<K1 extends string, K2 extends string, K3 extends string, K4 extends string, K5 extends string, K6 extends string, K7 extends string, K8 extends string, TResult>(path: [K1, K2, K3, K4, K5, K6, K7, K8], obj: Record<K1,Record<K2,Record<K3,Record<K4,Record<K5,Record<K6,Record<K7,Record<K8,TResult>>>>>>>>): TResult;
-        path<K1 extends string, K2 extends string, K3 extends string, K4 extends string, K5 extends string, K6 extends string, K7 extends string, K8 extends string, K9 extends string, TResult>(path: [K1, K2, K3, K4, K5, K6, K7, K8, K9], obj: Record<K1,Record<K2,Record<K3,Record<K4,Record<K5,Record<K6,Record<K7,Record<K8,Record<K9,TResult>>>>>>>>>): TResult;
+        path<K1 extends string, K2 extends string, TResult>(path: [K1, K2], obj: Record<K1,Record<K2,TResult>>): TResult | undefined;
+        path<K1 extends string, K2 extends string, K3 extends string, TResult>(path: [K1, K2, K3], obj: Record<K1,Record<K2,Record<K3,TResult>>>): TResult | undefined;
+        path<K1 extends string, K2 extends string, K3 extends string, K4 extends string, TResult>(path: [K1, K2, K3, K4], obj: Record<K1,Record<K2,Record<K3,Record<K4,TResult>>>>): TResult | undefined;
+        path<K1 extends string, K2 extends string, K3 extends string, K4 extends string, K5 extends string, TResult>(path: [K1, K2, K3, K4, K5], obj: Record<K1,Record<K2,Record<K3,Record<K4,Record<K5,TResult>>>>>): TResult | undefined;
+        path<K1 extends string, K2 extends string, K3 extends string, K4 extends string, K5 extends string, K6 extends string, TResult>(path: [K1, K2, K3, K4, K5, K6], obj: Record<K1,Record<K2,Record<K3,Record<K4,Record<K5,Record<K6,TResult>>>>>>): TResult | undefined;
+        path<K1 extends string, K2 extends string, K3 extends string, K4 extends string, K5 extends string, K6 extends string, K7 extends string, TResult>(path: [K1, K2, K3, K4, K5, K6, K7], obj: Record<K1,Record<K2,Record<K3,Record<K4,Record<K5,Record<K6,Record<K7,TResult>>>>>>>): TResult | undefined;
+        path<K1 extends string, K2 extends string, K3 extends string, K4 extends string, K5 extends string, K6 extends string, K7 extends string, K8 extends string, TResult>(path: [K1, K2, K3, K4, K5, K6, K7, K8], obj: Record<K1,Record<K2,Record<K3,Record<K4,Record<K5,Record<K6,Record<K7,Record<K8,TResult>>>>>>>>): TResult | undefined;
+        path<K1 extends string, K2 extends string, K3 extends string, K4 extends string, K5 extends string, K6 extends string, K7 extends string, K8 extends string, K9 extends string, TResult>(path: [K1, K2, K3, K4, K5, K6, K7, K8, K9], obj: Record<K1,Record<K2,Record<K3,Record<K4,Record<K5,Record<K6,Record<K7,Record<K8,Record<K9,TResult>>>>>>>>>): TResult | undefined;
 
         // for each path length list all combinations of objects and homogeneous arrays... tuples not supported yet.
 
-        path<T1 extends string, TResult>(path: [T1], obj: {[K1 in T1]: TResult}): TResult;
-        path<T1 extends number, TResult>(path: [T1], obj: TResult[]): TResult;
-        path<T1 extends string, T2 extends string, TResult>(path: [T1, T2], obj: {[K1 in T1]: {[K2 in T2]: TResult}}): TResult;
-        path<T1 extends string, T2 extends number, TResult>(path: [T1, T2], obj: {[K1 in T1]: TResult[]}): TResult;
-        path<T1 extends number, T2 extends string, TResult>(path: [T1, T2], obj: {[K2 in T2]: TResult}[]): TResult;
-        path<T1 extends number, T2 extends number, TResult>(path: [T1, T2], obj: TResult[][]): TResult;
-        path<T1 extends string, T2 extends string, T3 extends string, TResult>(path: [T1, T2, T3], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: TResult}}}): TResult;
-        path<T1 extends string, T2 extends string, T3 extends number, TResult>(path: [T1, T2, T3], obj: {[K1 in T1]: {[K2 in T2]: TResult[]}}): TResult;
-        path<T1 extends string, T2 extends number, T3 extends string, TResult>(path: [T1, T2, T3], obj: {[K1 in T1]: {[K3 in T3]: TResult}[]}): TResult;
-        path<T1 extends string, T2 extends number, T3 extends number, TResult>(path: [T1, T2, T3], obj: {[K1 in T1]: TResult[][]}): TResult;
-        path<T1 extends number, T2 extends string, T3 extends string, TResult>(path: [T1, T2, T3], obj: {[K2 in T2]: {[K3 in T3]: TResult}}[]): TResult;
-        path<T1 extends number, T2 extends string, T3 extends number, TResult>(path: [T1, T2, T3], obj: {[K2 in T2]: TResult[]}[]): TResult;
-        path<T1 extends number, T2 extends number, T3 extends string, TResult>(path: [T1, T2, T3], obj: {[K3 in T3]: TResult}[][]): TResult;
-        path<T1 extends number, T2 extends number, T3 extends number, TResult>(path: [T1, T2, T3], obj: TResult[][][]): TResult;
+        path<T1 extends string, TResult>(path: [T1], obj: {[K1 in T1]: TResult}): TResult | undefined;
+        path<T1 extends number, TResult>(path: [T1], obj: TResult[]): TResult | undefined;
+        path<T1 extends string, T2 extends string, TResult>(path: [T1, T2], obj: {[K1 in T1]: {[K2 in T2]: TResult}}): TResult | undefined;
+        path<T1 extends string, T2 extends number, TResult>(path: [T1, T2], obj: {[K1 in T1]: TResult[]}): TResult | undefined;
+        path<T1 extends number, T2 extends string, TResult>(path: [T1, T2], obj: {[K2 in T2]: TResult}[]): TResult | undefined;
+        path<T1 extends number, T2 extends number, TResult>(path: [T1, T2], obj: TResult[][]): TResult | undefined;
+        path<T1 extends string, T2 extends string, T3 extends string, TResult>(path: [T1, T2, T3], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: TResult}}}): TResult | undefined;
+        path<T1 extends string, T2 extends string, T3 extends number, TResult>(path: [T1, T2, T3], obj: {[K1 in T1]: {[K2 in T2]: TResult[]}}): TResult | undefined;
+        path<T1 extends string, T2 extends number, T3 extends string, TResult>(path: [T1, T2, T3], obj: {[K1 in T1]: {[K3 in T3]: TResult}[]}): TResult | undefined;
+        path<T1 extends string, T2 extends number, T3 extends number, TResult>(path: [T1, T2, T3], obj: {[K1 in T1]: TResult[][]}): TResult | undefined;
+        path<T1 extends number, T2 extends string, T3 extends string, TResult>(path: [T1, T2, T3], obj: {[K2 in T2]: {[K3 in T3]: TResult}}[]): TResult | undefined;
+        path<T1 extends number, T2 extends string, T3 extends number, TResult>(path: [T1, T2, T3], obj: {[K2 in T2]: TResult[]}[]): TResult | undefined;
+        path<T1 extends number, T2 extends number, T3 extends string, TResult>(path: [T1, T2, T3], obj: {[K3 in T3]: TResult}[][]): TResult | undefined;
+        path<T1 extends number, T2 extends number, T3 extends number, TResult>(path: [T1, T2, T3], obj: TResult[][][]): TResult | undefined;
         // path<T1 extends string, T2 extends string, T3 extends string, T4 extends string, TResult>(path: [T1, T2, T3, T4], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: {[K4 in T4]: TResult}}}}): TResult;
         // path<T1 extends string, T2 extends string, T3 extends string, T4 extends number, TResult>(path: [T1, T2, T3, T4], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: TResult[]}}}): TResult;
         // path<T1 extends string, T2 extends string, T3 extends number, T4 extends string, TResult>(path: [T1, T2, T3, T4], obj: {[K1 in T1]: {[K2 in T2]: {[K4 in T4]: TResult}[]}}): TResult;
@@ -2208,8 +2207,8 @@ declare namespace R {
         // path<T1 extends number, T2 extends number, T3 extends number, T4 extends number, T5 extends number, T6 extends number, TResult>(path: [T1, T2, T3, T4, T5, T6], obj: TResult[][][][][][]): TResult;
 
         // fallback, prevents errors but lacks inference; expected result must be supplied manually.
-        path<T>(path: Path, obj: Struct<any>): T;
-        path(path: Path): <T>(obj: Struct<any>) => T;
+        path<T>(path: Path, obj: Struct<any>): T | undefined;
+        path(path: Path): <T>(obj: Struct<any>) => T | undefined;
 
         // path<T>: CurriedFunction2<Path, Struct<any>, T>;
         // failed attempt at proper typing, see https://github.com/Microsoft/TypeScript/issues/12393 :
@@ -2502,7 +2501,7 @@ declare namespace R {
         prop<T>(p: Prop, obj: Struct<any>): T;
         // prop(p: Prop): <T>(obj: Struct<any>) => T;
         // prop<T>: CurriedFunction2<Prop, Struct<any>, T>;
-  
+
         // mixed for currying:
         prop<K extends string>(p: K): {
           // Record version

--- a/index.d.ts
+++ b/index.d.ts
@@ -1453,7 +1453,7 @@ declare namespace R {
          */
         length(list: List<any>): number;
 
-        /*
+        /**
          * Returns a lens for the given getter and setter functions. The getter
          * "gets" the value of the focus; the setter "sets" the value of the focus.
          * The setter should not mutate the data structure.

--- a/index.d.ts
+++ b/index.d.ts
@@ -681,6 +681,7 @@ declare namespace R {
         contains<T, U, R extends List<T|U>>(a: T, list: R): boolean;
         contains<T>(a: T): <U, R extends List<T|U>>(list: R) => boolean;
         // contains<T, U, R extends List<T|U>>: CurriedFunction2<T, R, boolean>;
+
         /**
          * Accepts a converging function and a list of branching functions and returns a new
          * function. When invoked, this new function is applied to some arguments, each branching

--- a/index.d.ts
+++ b/index.d.ts
@@ -1150,12 +1150,12 @@ declare namespace R {
          * Returns the first element in a list.
          * In some libraries this function is named `first`.
          */
-        head<T extends List<any>>(list: T): T[0];
+        head<T extends List<any>>(list: T): T[0] | undefined;
         head(list: string): string | undefined;
         // tuple attempts; it doesn't like these.
-        head<T>(list: [T]): T | undefined;
-        head<T0, T1>(list: [T0, T1]): T0 | undefined;
-        head<T0, T1, T2>(list: [T0, T1, T2]): T0 | undefined;
+        head<T>(list: [T]): T;
+        head<T0, T1>(list: [T0, T1]): T0;
+        head<T0, T1, T2>(list: [T0, T1, T2]): T0;
 
         /**
          * Returns true if its arguments are identical, false otherwise. Values are identical if they reference the
@@ -2059,14 +2059,14 @@ declare namespace R {
         // simpler versions, able to deal only with objects, not arrays:
 
         // in-based
-        path<T1 extends string, T2 extends string, TResult>(path: [T1, T2], obj: {[K1 in T1]: {[K2 in T2]: TResult}}): TResult | undefined;
-        path<T1 extends string, T2 extends string, T3 extends string, TResult>(path: [T1, T2, T3], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: TResult}}}): TResult | undefined;
-        path<T1 extends string, T2 extends string, T3 extends string, T4 extends string, TResult>(path: [T1, T2, T3, T4], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: {[K4 in T4]: TResult}}}}): TResult | undefined;
-        path<T1 extends string, T2 extends string, T3 extends string, T4 extends string, T5 extends string, TResult>(path: [T1, T2, T3, T4, T5], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: {[K4 in T4]: {[K5 in T5]: TResult}}}}}): TResult | undefined;
-        path<T1 extends string, T2 extends string, T3 extends string, T4 extends string, T5 extends string, T6 extends string, TResult>(path: [T1, T2, T3, T4, T5, T6], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: {[K4 in T4]: {[K5 in T5]: {[K6 in T6]: TResult}}}}}}): TResult | undefined;
-        path<T1 extends string, T2 extends string, T3 extends string, T4 extends string, T5 extends string, T6 extends string, T7 extends string, TResult>(path: [T1, T2, T3, T4, T5, T6, T7], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: {[K4 in T4]: {[K5 in T5]: {[K6 in T6]: {[K7 in T7]: TResult}}}}}}}): TResult | undefined;
-        path<T1 extends string, T2 extends string, T3 extends string, T4 extends string, T5 extends string, T6 extends string, T7 extends string, T8 extends string, TResult>(path: [T1, T2, T3, T4, T5, T6, T7, T8], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: {[K4 in T4]: {[K5 in T5]: {[K6 in T6]: {[K7 in T7]: {[K8 in T8]: TResult}}}}}}}}): TResult | undefined;
-        path<T1 extends string, T2 extends string, T3 extends string, T4 extends string, T5 extends string, T6 extends string, T7 extends string, T8 extends string, T9 extends string, TResult>(path: [T1, T2, T3, T4, T5, T6, T7, T8, T9], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: {[K4 in T4]: {[K5 in T5]: {[K6 in T6]: {[K7 in T7]: {[K8 in T8]: {[K9 in T9]: TResult}}}}}}}}}): TResult | undefined;
+        path<T1 extends string, T2 extends string, TResult>(path: [T1, T2], obj: {[K1 in T1]: {[K2 in T2]: TResult}}): TResult;
+        path<T1 extends string, T2 extends string, T3 extends string, TResult>(path: [T1, T2, T3], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: TResult}}}): TResult;
+        path<T1 extends string, T2 extends string, T3 extends string, T4 extends string, TResult>(path: [T1, T2, T3, T4], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: {[K4 in T4]: TResult}}}}): TResult;
+        path<T1 extends string, T2 extends string, T3 extends string, T4 extends string, T5 extends string, TResult>(path: [T1, T2, T3, T4, T5], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: {[K4 in T4]: {[K5 in T5]: TResult}}}}}): TResult;
+        path<T1 extends string, T2 extends string, T3 extends string, T4 extends string, T5 extends string, T6 extends string, TResult>(path: [T1, T2, T3, T4, T5, T6], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: {[K4 in T4]: {[K5 in T5]: {[K6 in T6]: TResult}}}}}}): TResult;
+        path<T1 extends string, T2 extends string, T3 extends string, T4 extends string, T5 extends string, T6 extends string, T7 extends string, TResult>(path: [T1, T2, T3, T4, T5, T6, T7], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: {[K4 in T4]: {[K5 in T5]: {[K6 in T6]: {[K7 in T7]: TResult}}}}}}}): TResult;
+        path<T1 extends string, T2 extends string, T3 extends string, T4 extends string, T5 extends string, T6 extends string, T7 extends string, T8 extends string, TResult>(path: [T1, T2, T3, T4, T5, T6, T7, T8], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: {[K4 in T4]: {[K5 in T5]: {[K6 in T6]: {[K7 in T7]: {[K8 in T8]: TResult}}}}}}}}): TResult;
+        path<T1 extends string, T2 extends string, T3 extends string, T4 extends string, T5 extends string, T6 extends string, T7 extends string, T8 extends string, T9 extends string, TResult>(path: [T1, T2, T3, T4, T5, T6, T7, T8, T9], obj: {[K1 in T1]: {[K2 in T2]: {[K3 in T3]: {[K4 in T4]: {[K5 in T5]: {[K6 in T6]: {[K7 in T7]: {[K8 in T8]: {[K9 in T9]: TResult}}}}}}}}}): TResult;
 
         // Record-based
         path<K1 extends string, K2 extends string, TResult>(path: [K1, K2], obj: Record<K1,Record<K2,TResult>>): TResult | undefined;

--- a/scripts.js
+++ b/scripts.js
@@ -139,17 +139,17 @@ function liftNDefSeparate(i) {
 R.flatten(R.range(2,10).map(i => liftNDefSeparate(i))).join('\n');
 
 function pathDef(i) {
-    let obj = R.range(1,i+1).reduce((str, n) => `{[K${i-n+1} in T${i-n+1}]: ${str}}`, 'TResult | undefined');
+    let obj = R.range(1,i+1).reduce((str, n) => `{[K${i-n+1} in T${i-n+1}]: ${str}}`, 'TResult');
     let types = nm(i, n => `T${n+1}`);
     let typesStr = nm(i, n => `T${n+1} extends string`);
-    return `path<${typesStr}, TResult>(path: [${types}], obj: ${obj}): TResult | undefined;`
+    return `path<${typesStr}, TResult>(path: [${types}], obj: ${obj}): TResult;`
 }
 
 function pathDefRecord(i) {
-    let obj = R.range(1,i+1).reduce((str, n) => `Record<K${i-n+1},${str}>`, 'TResult | undefined');
+    let obj = R.range(1,i+1).reduce((str, n) => `Record<K${i-n+1},${str}>`, 'TResult');
     let types = nm(i, n => `K${n+1}`);
     let typesStr = nm(i, n => `K${n+1} extends string`);
-    return `path<${typesStr}, TResult>(path: [${types}], obj: ${obj}): TResult | undefined;`
+    return `path<${typesStr}, TResult>(path: [${types}], obj: ${obj}): TResult;`
 }
 R.flatten(R.range(2,10).map(i => pathDefRecord(i))).join('\n')
 
@@ -159,7 +159,7 @@ function pathDefPoly(i, j) {
     let types = nm(i, n => `T${n+1}`);
     let typesExt = nm(i, n => `T${n+1} extends ${isArrs[i-n-1] ? 'number' : 'string'}`);
     // let typesExt = R.reverse(R.range(0,i).map(n => `T${n+1} extends ${isArrs[n] ? 'number' : 'string'}`)).join(', ');
-    return `path<${typesExt}, TResult>(path: [${types}], obj: ${obj}): TResult | undefined;`
+    return `path<${typesExt}, TResult>(path: [${types}], obj: ${obj}): TResult;`
 }
 R.flatten(R.range(1,7).map(i => R.range(0, Math.pow(2, i)).map(j => pathDefPoly(i, j)))).join('\n')
 

--- a/scripts.js
+++ b/scripts.js
@@ -2822,21 +2822,21 @@ head: {
     {
       list: '[T0, T1, T2]',
     },
-    'T0 | undefined',
+    'T0',
   ],
   'tuple': [
     ['T0', 'T1'],
     {
       list: '[T0, T1]',
     },
-    'T0 | undefined',
+    'T0',
   ],
   'single': [
     ['T'],
     {
       list: '[T]',
     },
-    'T | undefined'
+    'T'
   ],
   'any': [
     ['T extends List<any>'],

--- a/scripts.js
+++ b/scripts.js
@@ -139,17 +139,17 @@ function liftNDefSeparate(i) {
 R.flatten(R.range(2,10).map(i => liftNDefSeparate(i))).join('\n');
 
 function pathDef(i) {
-    let obj = R.range(1,i+1).reduce((str, n) => `{[K${i-n+1} in T${i-n+1}]: ${str}}`, 'TResult');
+    let obj = R.range(1,i+1).reduce((str, n) => `{[K${i-n+1} in T${i-n+1}]: ${str}}`, 'TResult | undefined');
     let types = nm(i, n => `T${n+1}`);
     let typesStr = nm(i, n => `T${n+1} extends string`);
-    return `path<${typesStr}, TResult>(path: [${types}], obj: ${obj}): TResult;`
+    return `path<${typesStr}, TResult>(path: [${types}], obj: ${obj}): TResult | undefined;`
 }
 
 function pathDefRecord(i) {
-    let obj = R.range(1,i+1).reduce((str, n) => `Record<K${i-n+1},${str}>`, 'TResult');
+    let obj = R.range(1,i+1).reduce((str, n) => `Record<K${i-n+1},${str}>`, 'TResult | undefined');
     let types = nm(i, n => `K${n+1}`);
     let typesStr = nm(i, n => `K${n+1} extends string`);
-    return `path<${typesStr}, TResult>(path: [${types}], obj: ${obj}): TResult;`
+    return `path<${typesStr}, TResult>(path: [${types}], obj: ${obj}): TResult | undefined;`
 }
 R.flatten(R.range(2,10).map(i => pathDefRecord(i))).join('\n')
 
@@ -159,7 +159,7 @@ function pathDefPoly(i, j) {
     let types = nm(i, n => `T${n+1}`);
     let typesExt = nm(i, n => `T${n+1} extends ${isArrs[i-n-1] ? 'number' : 'string'}`);
     // let typesExt = R.reverse(R.range(0,i).map(n => `T${n+1} extends ${isArrs[n] ? 'number' : 'string'}`)).join(', ');
-    return `path<${typesExt}, TResult>(path: [${types}], obj: ${obj}): TResult;`
+    return `path<${typesExt}, TResult>(path: [${types}], obj: ${obj}): TResult | undefined;`
 }
 R.flatten(R.range(1,7).map(i => R.range(0, Math.pow(2, i)).map(j => pathDefPoly(i, j)))).join('\n')
 
@@ -645,7 +645,7 @@ defaultTo: [
   ['T', 'U'],
   {
     a: 'T',
-    b: 'U',
+    b: 'U | null | undefined',
   },
   'T|U',
 ],
@@ -1719,7 +1719,7 @@ invert: [
 invertObj: [
   [],
   {
-    obj: 'Struct<Prop>' 
+    obj: 'Struct<Prop>'
   },
   'Obj<string>'
 ],
@@ -2170,7 +2170,7 @@ propIs: {
     'boolean'
   ],
   // unsure
-  // 'mixed': 
+  // 'mixed':
 },
 
 propSatisfies: {
@@ -2822,21 +2822,21 @@ head: {
     {
       list: '[T0, T1, T2]',
     },
-    'T0',
+    'T0 | undefined',
   ],
   'tuple': [
     ['T0', 'T1'],
     {
       list: '[T0, T1]',
     },
-    'T0',
+    'T0 | undefined',
   ],
   'single': [
     ['T'],
     {
       list: '[T]',
     },
-    'T'
+    'T | undefined'
   ],
   'any': [
     ['T extends List<any>'],


### PR DESCRIPTION
This PR corrects the typings to more accurately reflect Ramda behavior. In particular, these typings do not behave appropriately in all contexts with `strictNullChecks` enabled.

As a minimal example:

```typescript
import * as R from './index';

const addOne = (
  n: number,
): number => n + 1;

const x: number | null = ((): number | null => 3)();
const defaultedValue = R.defaultTo(4, x);

const result = addOne(defaultedValue);
```

yields:

```
toy.ts(10,23): error TS2345: Argument of type 'number | null' is not assignable to parameter of type 'number'.
  Type 'null' is not assignable to type 'number'.
```

We correct this by specifying that the second argument to `defaultTo` can be null or undefined but that it only returns `U` or `T`.

The other changes reflect the fact that Ramda may return undefined for those functions in some contexts.

I did not use the scripts to fix these errors, but I attempted to modify it post-fact in order to reflect these changes. Please let me know if I did so incorrectly. 