### PR TITLE
Support placeholder in CurriedFunction interfaces

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -167,7 +167,7 @@ declare namespace R {
     // @see https://gist.github.com/donnut/fd56232da58d25ceecf1, comment by @albrow
     // @see https://github.com/types/npm-ramda/issues/173
 
-    type PH = { "@@functional/placeholder": true };
+    type PH = { '@@functional/placeholder': true };
     type CurriedFunction1<T1, R> = (v1: T1) => R;
     interface CurriedFunction2<T1, T2, R> {
         (_1: PH, v2: T2): CurriedFunction1<T1, R>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -165,71 +165,138 @@ declare namespace R {
     }
 
     // @see https://gist.github.com/donnut/fd56232da58d25ceecf1, comment by @albrow
+    // @see https://github.com/types/npm-ramda/issues/173
 
-    // interface CurriedFunction1<T1, R> {
-    //     (v1: T1): R;
-    // }
+    type PH = { "@@functional/placeholder": true };
     type CurriedFunction1<T1, R> = (v1: T1) => R;
-
     interface CurriedFunction2<T1, T2, R> {
-        (v1: T1): (v2: T2) => R;
+        (_1: PH, v2: T2): CurriedFunction1<T1, R>;
         (v1: T1, v2: T2): R;
+        (v1: T1): CurriedFunction1<T2, R>;
     }
     interface CurriedFunction3<T1, T2, T3, R> {
-        (v1: T1): CurriedFunction2<T2, T3, R>;
-        (v1: T1, v2: T2): (v3: T3) => R;
+        (v1: T1, _2: PH, v3: T3): CurriedFunction1<T2, R>;
+        (_1: PH, v2: T2, v3: T3): CurriedFunction1<T1, R>;
+        (_1: PH, _2: PH, v3: T3): CurriedFunction2<T1, T2, R>;
         (v1: T1, v2: T2, v3: T3): R;
+        (_1: PH, v2: T2): CurriedFunction2<T1, T3, R>;
+        (v1: T1, v2: T2): CurriedFunction1<T3, R>;
+        (v1: T1): CurriedFunction2<T2, T3, R>;
     }
     interface CurriedFunction4<T1, T2, T3, T4, R> {
-        (v1: T1): CurriedFunction3<T2, T3, T4, R>;
-        (v1: T1, v2: T2): CurriedFunction2<T3, T4, R>;
-        (v1: T1, v2: T2, v3: T3): (v4: T4) => R;
+        (v1: T1, v2: T2, _3: PH, v4: T4): CurriedFunction1<T3, R>;
+        (v1: T1, _2: PH, _3: PH, v4: T4): CurriedFunction2<T2, T3, R>;
+        (v1: T1, _2: PH, v3: T3, v4: T4): CurriedFunction1<T2, R>;
+        (_1: PH, v2: T2, _3: PH, v4: T4): CurriedFunction2<T1, T3, R>;
+        (_1: PH, _2: PH, _3: PH, v4: T4): CurriedFunction3<T1, T2, T3, R>;
+        (_1: PH, v2: T2, v3: T3, v4: T4): CurriedFunction1<T1, R>;
+        (_1: PH, _2: PH, v3: T3, v4: T4): CurriedFunction2<T1, T2, R>;
         (v1: T1, v2: T2, v3: T3, v4: T4): R;
+        (v1: T1, _2: PH, v3: T3): CurriedFunction2<T2, T4, R>;
+        (_1: PH, v2: T2, v3: T3): CurriedFunction2<T1, T4, R>;
+        (_1: PH, _2: PH, v3: T3): CurriedFunction3<T1, T2, T4, R>;
+        (v1: T1, v2: T2, v3: T3): CurriedFunction1<T4, R>;
+        (_1: PH, v2: T2): CurriedFunction3<T1, T3, T4, R>;
+        (v1: T1, v2: T2): CurriedFunction2<T3, T4, R>;
+        (v1: T1): CurriedFunction3<T2, T3, T4, R>;
     }
     interface CurriedFunction5<T1, T2, T3, T4, T5, R> {
-        (v1: T1): CurriedFunction4<T2, T3, T4, T5, R>;
-        (v1: T1, v2: T2): CurriedFunction3<T3, T4, T5, R>;
-        (v1: T1, v2: T2, v3: T3): CurriedFunction2<T4, T5, R>;
-        (v1: T1, v2: T2, v3: T3, v4: T4): (v5: T5) => R;
+        (v1: T1, v2: T2, v3: T3, _4: PH, v5: T5): CurriedFunction1<T4, R>;
+        (v1: T1, v2: T2, _3: PH, v4: T4, v5: T5): CurriedFunction1<T3, R>;
+        (v1: T1, v2: T2, _3: PH, _4: PH, v5: T5): CurriedFunction2<T3, T4, R>;
+        (v1: T1, _2: PH, _3: PH, _4: PH, v5: T5): CurriedFunction3<T2, T3, T4, R>;
+        (v1: T1, _2: PH, v3: T3, v4: T4, v5: T5): CurriedFunction1<T2, R>;
+        (v1: T1, _2: PH, v3: T3, _4: PH, v5: T5): CurriedFunction2<T2, T4, R>;
+        (v1: T1, _2: PH, _3: PH, v4: T4, v5: T5): CurriedFunction2<T2, T3, R>;
+        (_1: PH, _2: PH, _3: PH, v4: T4, v5: T5): CurriedFunction3<T1, T2, T3, R>;
+        (_1: PH, _2: PH, v3: T3, _4: PH, v5: T5): CurriedFunction3<T1, T2, T4, R>;
+        (_1: PH, v2: T2, _3: PH, v4: T4, v5: T5): CurriedFunction2<T1, T3, R>;
+        (_1: PH, v2: T2, v3: T3, _4: PH, v5: T5): CurriedFunction2<T1, T4, R>;
+        (_1: PH, _2: PH, v3: T3, v4: T4, v5: T5): CurriedFunction2<T1, T2, R>;
+        (_1: PH, _2: PH, _3: PH, _4: PH, v5: T5): CurriedFunction4<T1, T2, T3, T4, R>;
+        (_1: PH, v2: T2, v3: T3, v4: T4, v5: T5): CurriedFunction1<T1, R>;
+        (_1: PH, v2: T2, _3: PH, _4: PH, v5: T5): CurriedFunction3<T1, T3, T4, R>;
         (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5): R;
+        (v1: T1, v2: T2, _3: PH, v4: T4): CurriedFunction2<T3, T5, R>;
+        (v1: T1, _2: PH, _3: PH, v4: T4): CurriedFunction3<T2, T3, T5, R>;
+        (v1: T1, _2: PH, v3: T3, v4: T4): CurriedFunction2<T2, T5, R>;
+        (_1: PH, v2: T2, _3: PH, v4: T4): CurriedFunction3<T1, T3, T5, R>;
+        (_1: PH, _2: PH, _3: PH, v4: T4): CurriedFunction4<T1, T2, T3, T5, R>;
+        (_1: PH, v2: T2, v3: T3, v4: T4): CurriedFunction2<T1, T5, R>;
+        (_1: PH, _2: PH, v3: T3, v4: T4): CurriedFunction3<T1, T2, T5, R>;
+        (v1: T1, v2: T2, v3: T3, v4: T4): CurriedFunction1<T5, R>;
+        (v1: T1, _2: PH, v3: T3): CurriedFunction3<T2, T4, T5, R>;
+        (_1: PH, _2: PH, v3: T3): CurriedFunction4<T1, T2, T4, T5, R>;
+        (_1: PH, v2: T2, v3: T3): CurriedFunction3<T1, T4, T5, R>;
+        (v1: T1, v2: T2, v3: T3): CurriedFunction2<T4, T5, R>;
+        (_1: PH, v2: T2): CurriedFunction4<T1, T3, T4, T5, R>;
+        (v1: T1, v2: T2): CurriedFunction3<T3, T4, T5, R>;
+        (v1: T1): CurriedFunction4<T2, T3, T4, T5, R>;
     }
     interface CurriedFunction6<T1, T2, T3, T4, T5, T6, R> {
-        (v1: T1): CurriedFunction5<T2, T3, T4, T5, T6, R>;
-        (v1: T1, v2: T2): CurriedFunction4<T3, T4, T5, T6, R>;
-        (v1: T1, v2: T2, v3: T3): CurriedFunction3<T4, T5, T6, R>;
-        (v1: T1, v2: T2, v3: T3, v4: T4): CurriedFunction2<T5, T6, R>;
-        (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5): (v6: T6) => R;
+        (v1: T1, v2: T2, v3: T3, v4: T4, _5: PH, v6: T6): CurriedFunction1<T5, R>;
+        (v1: T1, v2: T2, v3: T3, _4: PH, v5: T5, v6: T6): CurriedFunction1<T4, R>;
+        (v1: T1, v2: T2, v3: T3, _4: PH, _5: PH, v6: T6): CurriedFunction2<T4, T5, R>;
+        (v1: T1, v2: T2, _3: PH, _4: PH, _5: PH, v6: T6): CurriedFunction3<T3, T4, T5, R>;
+        (v1: T1, v2: T2, _3: PH, v4: T4, v5: T5, v6: T6): CurriedFunction1<T3, R>;
+        (v1: T1, v2: T2, _3: PH, v4: T4, _5: PH, v6: T6): CurriedFunction2<T3, T5, R>;
+        (v1: T1, v2: T2, _3: PH, _4: PH, v5: T5, v6: T6): CurriedFunction2<T3, T4, R>;
+        (v1: T1, _2: PH, _3: PH, _4: PH, _5: PH, v6: T6): CurriedFunction4<T2, T3, T4, T5, R>;
+        (v1: T1, _2: PH, v3: T3, v4: T4, v5: T5, v6: T6): CurriedFunction1<T2, R>;
+        (v1: T1, _2: PH, v3: T3, v4: T4, _5: PH, v6: T6): CurriedFunction2<T2, T5, R>;
+        (v1: T1, _2: PH, v3: T3, _4: PH, v5: T5, v6: T6): CurriedFunction2<T2, T4, R>;
+        (v1: T1, _2: PH, v3: T3, _4: PH, _5: PH, v6: T6): CurriedFunction3<T2, T4, T5, R>;
+        (v1: T1, _2: PH, _3: PH, v4: T4, v5: T5, v6: T6): CurriedFunction2<T2, T3, R>;
+        (v1: T1, _2: PH, _3: PH, v4: T4, _5: PH, v6: T6): CurriedFunction3<T2, T3, T5, R>;
+        (v1: T1, _2: PH, _3: PH, _4: PH, v5: T5, v6: T6): CurriedFunction3<T2, T3, T4, R>;
+        (_1: PH, _2: PH, _3: PH, _4: PH, _5: PH, v6: T6): CurriedFunction5<T1, T2, T3, T4, T5, R>;
+        (_1: PH, _2: PH, v3: T3, _4: PH, v5: T5, v6: T6): CurriedFunction3<T1, T2, T4, R>;
+        (_1: PH, v2: T2, _3: PH, _4: PH, v5: T5, v6: T6): CurriedFunction3<T1, T3, T4, R>;
+        (_1: PH, v2: T2, _3: PH, v4: T4, _5: PH, v6: T6): CurriedFunction3<T1, T3, T5, R>;
+        (_1: PH, v2: T2, _3: PH, v4: T4, v5: T5, v6: T6): CurriedFunction2<T1, T3, R>;
+        (_1: PH, _2: PH, _3: PH, _4: PH, v5: T5, v6: T6): CurriedFunction4<T1, T2, T3, T4, R>;
+        (_1: PH, _2: PH, _3: PH, v4: T4, _5: PH, v6: T6): CurriedFunction4<T1, T2, T3, T5, R>;
+        (_1: PH, v2: T2, v3: T3, _4: PH, _5: PH, v6: T6): CurriedFunction3<T1, T4, T5, R>;
+        (_1: PH, _2: PH, v3: T3, v4: T4, _5: PH, v6: T6): CurriedFunction3<T1, T2, T5, R>;
+        (_1: PH, _2: PH, v3: T3, v4: T4, v5: T5, v6: T6): CurriedFunction2<T1, T2, R>;
+        (_1: PH, v2: T2, v3: T3, _4: PH, v5: T5, v6: T6): CurriedFunction2<T1, T4, R>;
+        (_1: PH, v2: T2, v3: T3, v4: T4, _5: PH, v6: T6): CurriedFunction2<T1, T5, R>;
+        (_1: PH, _2: PH, _3: PH, v4: T4, v5: T5, v6: T6): CurriedFunction3<T1, T2, T3, R>;
+        (_1: PH, _2: PH, v3: T3, _4: PH, _5: PH, v6: T6): CurriedFunction4<T1, T2, T4, T5, R>;
+        (_1: PH, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6): CurriedFunction1<T1, R>;
+        (_1: PH, v2: T2, _3: PH, _4: PH, _5: PH, v6: T6): CurriedFunction4<T1, T3, T4, T5, R>;
         (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6): R;
-    }
-    interface CurriedFunction7<T1, T2, T3, T4, T5, T6, T7, R> {
-        (v1: T1): CurriedFunction6<T2, T3, T4, T5, T6, T7, R>;
-        (v1: T1, v2: T2): CurriedFunction5<T3, T4, T5, T6, T7, R>;
-        (v1: T1, v2: T2, v3: T3): CurriedFunction4<T4, T5, T6, T7, R>;
-        (v1: T1, v2: T2, v3: T3, v4: T4): CurriedFunction3<T5, T6, T7, R>;
-        (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5): CurriedFunction2<T6, T7, R>;
-        (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6): (v7: T7) => R;
-        (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7): R;
-    }
-    interface CurriedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> {
-        (v1: T1): CurriedFunction7<T2, T3, T4, T5, T6, T7, T8, R>;
-        (v1: T1, v2: T2): CurriedFunction6<T3, T4, T5, T6, T7, T8, R>;
-        (v1: T1, v2: T2, v3: T3): CurriedFunction5<T4, T5, T6, T7, T8, R>;
-        (v1: T1, v2: T2, v3: T3, v4: T4): CurriedFunction4<T5, T6, T7, T8, R>;
-        (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5): CurriedFunction3<T6, T7, T8, R>;
-        (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6): CurriedFunction2<T7, T8, R>;
-        (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7): (v8: T8) => R;
-        (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8): R;
-    }
-    interface CurriedFunction9<T1, T2, T3, T4, T5, T6, T7, T8, T9, R> {
-        (v1: T1): CurriedFunction8<T2, T3, T4, T5, T6, T7, T8, T9, R>;
-        (v1: T1, v2: T2): CurriedFunction7<T3, T4, T5, T6, T7, T8, T9, R>;
-        (v1: T1, v2: T2, v3: T3): CurriedFunction6<T4, T5, T6, T7, T8, T9, R>;
-        (v1: T1, v2: T2, v3: T3, v4: T4): CurriedFunction5<T5, T6, T7, T8, T9, R>;
-        (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5): CurriedFunction4<T6, T7, T8, T9, R>;
-        (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6): CurriedFunction3<T7, T8, T9, R>;
-        (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7): CurriedFunction2<T8, T9, R>;
-        (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8): (v9: T9) => R;
-        (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9): R;
+        (v1: T1, v2: T2, v3: T3, _4: PH, v5: T5): CurriedFunction2<T4, T6, R>;
+        (v1: T1, v2: T2, _3: PH, _4: PH, v5: T5): CurriedFunction3<T3, T4, T6, R>;
+        (v1: T1, v2: T2, _3: PH, v4: T4, v5: T5): CurriedFunction2<T3, T6, R>;
+        (v1: T1, _2: PH, _3: PH, _4: PH, v5: T5): CurriedFunction4<T2, T3, T4, T6, R>;
+        (v1: T1, _2: PH, _3: PH, v4: T4, v5: T5): CurriedFunction3<T2, T3, T6, R>;
+        (v1: T1, _2: PH, v3: T3, _4: PH, v5: T5): CurriedFunction3<T2, T4, T6, R>;
+        (v1: T1, _2: PH, v3: T3, v4: T4, v5: T5): CurriedFunction2<T2, T6, R>;
+        (_1: PH, v2: T2, v3: T3, v4: T4, v5: T5): CurriedFunction2<T1, T6, R>;
+        (_1: PH, v2: T2, _3: PH, v4: T4, v5: T5): CurriedFunction3<T1, T3, T6, R>;
+        (_1: PH, v2: T2, v3: T3, _4: PH, v5: T5): CurriedFunction3<T1, T4, T6, R>;
+        (_1: PH, _2: PH, _3: PH, v4: T4, v5: T5): CurriedFunction4<T1, T2, T3, T6, R>;
+        (_1: PH, v2: T2, _3: PH, _4: PH, v5: T5): CurriedFunction4<T1, T3, T4, T6, R>;
+        (_1: PH, _2: PH, v3: T3, _4: PH, v5: T5): CurriedFunction4<T1, T2, T4, T6, R>;
+        (_1: PH, _2: PH, _3: PH, _4: PH, v5: T5): CurriedFunction5<T1, T2, T3, T4, T6, R>;
+        (_1: PH, _2: PH, v3: T3, v4: T4, v5: T5): CurriedFunction3<T1, T2, T6, R>;
+        (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5): CurriedFunction1<T6, R>;
+        (v1: T1, v2: T2, _3: PH, v4: T4): CurriedFunction3<T3, T5, T6, R>;
+        (v1: T1, _2: PH, v3: T3, v4: T4): CurriedFunction3<T2, T5, T6, R>;
+        (v1: T1, _2: PH, _3: PH, v4: T4): CurriedFunction4<T2, T3, T5, T6, R>;
+        (_1: PH, v2: T2, _3: PH, v4: T4): CurriedFunction4<T1, T3, T5, T6, R>;
+        (_1: PH, _2: PH, v3: T3, v4: T4): CurriedFunction4<T1, T2, T5, T6, R>;
+        (_1: PH, v2: T2, v3: T3, v4: T4): CurriedFunction3<T1, T5, T6, R>;
+        (_1: PH, _2: PH, _3: PH, v4: T4): CurriedFunction5<T1, T2, T3, T5, T6, R>;
+        (v1: T1, v2: T2, v3: T3, v4: T4): CurriedFunction2<T5, T6, R>;
+        (v1: T1, _2: PH, v3: T3): CurriedFunction4<T2, T4, T5, T6, R>;
+        (_1: PH, _2: PH, v3: T3): CurriedFunction5<T1, T2, T4, T5, T6, R>;
+        (_1: PH, v2: T2, v3: T3): CurriedFunction4<T1, T4, T5, T6, R>;
+        (v1: T1, v2: T2, v3: T3): CurriedFunction3<T4, T5, T6, R>;
+        (_1: PH, v2: T2): CurriedFunction5<T1, T3, T4, T5, T6, R>;
+        (v1: T1, v2: T2): CurriedFunction4<T3, T4, T5, T6, R>;
+        (v1: T1): CurriedFunction5<T2, T3, T4, T5, T6, R>;
     }
 
     interface Reduced {}
@@ -241,8 +308,9 @@ declare namespace R {
         * functions, allowing partial application of any combination of
         * arguments, regardless of their positions.
         * NOTE: can't type this yet, for binary functions consider R.flip!
+        * NOTE: Currently only support CurriedFunction interfaces.
         */
-       __: any; // { "@@functional/placeholder": boolean };
+       __: PH;
        // ^ don't type by value, since it can be inserted anywhere...
        // Note this is still not useful, as it doesn't take into account how it changes formulas (leaving holes!).
        // This remains TODO, and should be done on the level of curried functions, but that
@@ -710,9 +778,6 @@ declare namespace R {
         curry<T1, T2, T3, T4, TResult>(fn: (a: T1, b: T2, c: T3, d: T4) => TResult): CurriedFunction4<T1, T2, T3, T4, TResult>;
         curry<T1, T2, T3, T4, T5, TResult>(fn: (a: T1, b: T2, c: T3, d: T4, e: T5) => TResult): CurriedFunction5<T1, T2, T3, T4, T5, TResult>;
         curry<T1, T2, T3, T4, T5, T6, TResult>(fn: (a: T1, b: T2, c: T3, d: T4, e: T5, f: T6) => TResult): CurriedFunction6<T1, T2, T3, T4, T5, T6, TResult>;
-        curry<T1, T2, T3, T4, T5, T6, T7, TResult>(fn: (a: T1, b: T2, c: T3, d: T4, e: T5, f: T6, g: T7) => TResult): CurriedFunction7<T1, T2, T3, T4, T5, T6, T7, TResult>;
-        curry<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(fn: (a: T1, b: T2, c: T3, d: T4, e: T5, f: T6, g: T7, h: T8) => TResult): CurriedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, TResult>;
-        curry<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(fn: (a: T1, b: T2, c: T3, d: T4, e: T5, f: T6, g: T7, h: T8, i: T9) => TResult): CurriedFunction9<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>;
         // curry(fn: Function): Function
 
 

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -79,7 +79,7 @@ class F2 {
 // curry
 () => {
     const addTwo = R.curry((x: number, y: number) => x + y);
-    // $ExpectType (v2: number) => number
+    // $ExpectType CurriedFunction1<number, number>
     addTwo(3);
     // $ExpectType number
     addTwo(3)(1);
@@ -88,9 +88,9 @@ class F2 {
     addThree(3, 2, 1);
     // $ExpectType number
     addThree(3)(2)(1);
-    // $ExpectType (v3: number) => number
+    // $ExpectType CurriedFunction1<number, number>
     addThree(3, 2);
-    // $ExpectType (v2: number) => number
+    // $ExpectType CurriedFunction1<number, number>
     addThree(3)(2);
     // $ExpectType CurriedFunction2<number, number, number>
     addThree(3);

--- a/tests/test.ts.out
+++ b/tests/test.ts.out
@@ -7,7 +7,7 @@ tests/test.ts:xy(3);
 Expected type
   <Y>(v2: Y) => { x: number; y: Y; }
 but got:
-  (v2: {}) => { x: {}; y: {}; }
+  CurriedFunction1<{}, { x: {}; y: {}; }>
 
 tests/test.ts:xy(3)(1);
 
@@ -35,14 +35,14 @@ tests/test.ts:xyz(3, 2);
 Expected type
   <Z>(v3: Z) => ({ x: number; y: number; z: Z; })
 but got:
-  (v3: {}) => { x: {}; y: {}; z: {}; }
+  CurriedFunction1<{}, { x: {}; y: {}; z: {}; }>
 
 tests/test.ts:xyz(3)(2);
 
 Expected type
   <Z>(v3: Z) => ({ x: number; y: number; z: Z; })
 but got:
-  (v2: {}) => { x: {}; y: {}; z: {}; }
+  CurriedFunction1<{}, { x: {}; y: {}; z: {}; }>
 
 tests/test.ts:xyz(3);
 
@@ -56,14 +56,14 @@ tests/test.ts:curriedFourNumbers(1)(2)(3);
 Expected type
   <T1,R>(v1: T1) => R
 but got:
-  (v2: number) => number
+  CurriedFunction1<number, number>
 
 tests/test.ts:curriedFourNumbers(1,2,4);
 
 Expected type
   <T1,R>(v1: T1) => R
 but got:
-  (v4: number) => number
+  CurriedFunction1<number, number>
 
 tests/test.ts:R.nAry(0, takesNoArg);
 
@@ -1515,7 +1515,7 @@ tests/test.ts:mapIndexed(function(val: string, idx: number) {return idx + '-' + 
 Expected type
   string[]
 but got:
-  (v2: List<string>) => string
+  CurriedFunction1<List<string>, string>
 
 tests/test.ts:reduceIndexed(
       (acc: string, val: string, idx: number) => acc + ',' + idx + '-' + val
@@ -1584,7 +1584,21 @@ Expected type
 but got:
   {} | undefined
 
+tests/test.ts:sortByAgeDescending(people);
+
+Expected type
+  { name: string, age: number }[]
+but got:
+  Struct<any>[]
+
 tests/test.ts:sortByNameCaseInsensitive(people);
+
+Expected type
+  { name: string, age: number }[]
+but got:
+  Struct<any>[]
+
+tests/test.ts:sortByAgeAscending(people);
 
 Expected type
   { name: string, age: number }[]
@@ -1846,13 +1860,11 @@ but got:
 
 tests/test.ts: Unexpected error
   Argument of type 'CurriedFunction2<{}, Struct<{}>, Struct<{}>>' is not assignable to parameter of type '(some: string) => (x: number) => 1'.
-  Type '(v2: Struct<{}>) => Struct<{}>' is not assignable to type '(x: number) => 1'.
-    Types of parameters 'v2' and 'x' are incompatible.
-      Type 'number' is not assignable to type 'Struct<{}>'.
 
 tests/test.ts: Unexpected error
   Argument of type 'CurriedFunction2<{}, Struct<{}>, Struct<{}>>' is not assignable to parameter of type '(some: string, other: string) => "1"'.
-  Type '(v2: Struct<{}>) => Struct<{}>' is not assignable to type '"1"'.
+  Types of parameters '_1' and 'some' are incompatible.
+    Type 'string' is not assignable to type 'PH'.
 
 tests/test.ts:const x = R.cond([
         [R.F, R.F],
@@ -1904,4 +1916,4 @@ Expected type
 but got:
   { b: number; }
 
-tests/test.ts: 450 / 725 checks passed.
+tests/test.ts: 450 / 727 checks passed.


### PR DESCRIPTION
* add placeholder type (PH)
* remove CurriedFunction(7~8)
* remove curry(7~8)

related #173 

NOTE that there may be some breaking changes in tests due to the overloads' ordering in CurriedFunctions.