### PR TITLE
fix(adjust): add tuple kind

### DIFF
--- a/snapshots/adjust.ts
+++ b/snapshots/adjust.ts
@@ -4,6 +4,7 @@ import R_adjust = require('../ramda/dist/src/adjust');
 declare const string_to_string: Morphism<string, string>;
 declare const string_to_number: Morphism<string, number>;
 declare const string_array: string[];
+declare const string_number_tuple: [string, number];
 declare const number: number;
 
 // @dts-jest:pass:snap -> (string | number)[]
@@ -18,3 +19,8 @@ R_adjust(string_to_string)(number, string_array);
 R_adjust(string_to_string, number)(string_array);
 // @dts-jest:pass:snap -> string[]
 R_adjust(string_to_string, number, string_array);
+
+// @dts-jest:pass:snap -> [string, number]
+R_adjust<'111', 'tuple'>()(string_to_string, 0, string_number_tuple);
+// @dts-jest:fail:snap -> Argument of type 'Morphism<string, string>' is not assignable to parameter of type 'Morphism<number, number>'.
+R_adjust<'111', 'tuple'>()(string_to_string, 1, string_number_tuple);

--- a/snapshots/ramda-tests.ts
+++ b/snapshots/ramda-tests.ts
@@ -3308,3 +3308,20 @@ import * as R from '../ramda/dist/index';
   // @dts-jest:pass:snap -> void[]
   R.zipWith(f, [1, 2, 3])(['a', 'b', 'c']); //=> [f(1, 'a'), f(2, 'b'), f(3, 'c')]
 })();
+
+// @dts-jest:group issue-273
+(() => {
+  const mapKeyPairs = R.curry(
+    (
+      fn: (key: string) => string,
+      obj: { [k: string]: any } | { [k: number]: any },
+    ) => R.map(R.adjust<0, [string, any]>(fn, 0), R.toPairs(obj)),
+  );
+
+  const mapKey = R.pipe(mapKeyPairs, R.fromPairs);
+
+  // @dts-jest:pass:snap -> [string, any][]
+  mapKeyPairs((key: string) => `x${key}`, { a: 1, b: 2, c: 3 }); //=> [['xa', 1], ['xb', 2], ['xc', 3]]
+  // @dts-jest:pass:snap -> Dictionary<any>
+  mapKey((key: string) => `x${key}`, { a: 1, b: 2, c: 3 }); //=> { xa: 1, xb: 2, xc: 3 }
+})();

--- a/templates/adjust.d.ts
+++ b/templates/adjust.d.ts
@@ -1,7 +1,19 @@
 import { List, Morphism } from './$types';
 
-export function $<T, U>(
+export function $list<T, U>(
   fn: Morphism<T, U>,
   index: number,
   list: List<T>,
 ): Array<T | U>;
+
+export function $tuple<N extends number, X extends [any]>(
+  fn: Morphism<X[N], X[N]>,
+  index: N,
+  tuple: X,
+): X;
+
+export function $general<T, U, X extends [any]>(
+  fn: Morphism<T, U>,
+  index: number,
+  list: List<T> | X,
+): Array<T | U> | X;

--- a/tests/__snapshots__/adjust.ts.snap
+++ b/tests/__snapshots__/adjust.ts.snap
@@ -11,3 +11,11 @@ exports[`R_adjust(string_to_string)(number, string_array) 1`] = `"string[]"`;
 exports[`R_adjust(string_to_string, number)(string_array) 1`] = `"string[]"`;
 
 exports[`R_adjust(string_to_string, number, string_array) 1`] = `"string[]"`;
+
+exports[`R_adjust<'111', 'tuple'>()(string_to_string, 0, string_number_tuple) 1`] = `"[string, number]"`;
+
+exports[`R_adjust<'111', 'tuple'>()(string_to_string, 1, string_number_tuple) 1`] = `
+"Argument of type 'Morphism<string, string>' is not assignable to parameter of type 'Morphism<number, number>'.
+  Types of parameters 'value' and 'value' are incompatible.
+    Type 'number' is not assignable to type 'string'."
+`;

--- a/tests/__snapshots__/ramda-tests.ts.snap
+++ b/tests/__snapshots__/ramda-tests.ts.snap
@@ -648,6 +648,10 @@ exports[`isNil R.isNil(null) 1`] = `"boolean"`;
 
 exports[`isNil R.isNil(undefined) 1`] = `"boolean"`;
 
+exports[`issue-273 mapKey((key: string) => \`x\${key}\`, { a: 1, b: 2, c: 3 }) 1`] = `"Dictionary<any>"`;
+
+exports[`issue-273 mapKeyPairs((key: string) => \`x\${key}\`, { a: 1, b: 2, c: 3 }) 1`] = `"[string, any][]"`;
+
 exports[`join R.join('|', [1, 2, 3]) 1`] = `"string"`;
 
 exports[`join spacer(['a', 2, 3.4]) 1`] = `"string"`;

--- a/tests/adjust.ts
+++ b/tests/adjust.ts
@@ -4,6 +4,7 @@ import R_adjust = require('../ramda/dist/src/adjust');
 declare const string_to_string: Morphism<string, string>;
 declare const string_to_number: Morphism<string, number>;
 declare const string_array: string[];
+declare const string_number_tuple: [string, number];
 declare const number: number;
 
 // @dts-jest:pass:snap
@@ -18,3 +19,8 @@ R_adjust(string_to_string)(number, string_array);
 R_adjust(string_to_string, number)(string_array);
 // @dts-jest:pass:snap
 R_adjust(string_to_string, number, string_array);
+
+// @dts-jest:pass:snap
+R_adjust<'111', 'tuple'>()(string_to_string, 0, string_number_tuple);
+// @dts-jest:fail:snap
+R_adjust<'111', 'tuple'>()(string_to_string, 1, string_number_tuple);

--- a/tests/ramda-tests.ts
+++ b/tests/ramda-tests.ts
@@ -3308,3 +3308,20 @@ import * as R from '../ramda/dist/index';
   // @dts-jest:pass:snap
   R.zipWith(f, [1, 2, 3])(['a', 'b', 'c']); //=> [f(1, 'a'), f(2, 'b'), f(3, 'c')]
 })();
+
+// @dts-jest:group issue-273
+(() => {
+  const mapKeyPairs = R.curry(
+    (
+      fn: (key: string) => string,
+      obj: { [k: string]: any } | { [k: number]: any },
+    ) => R.map(R.adjust<0, [string, any]>(fn, 0), R.toPairs(obj)),
+  );
+
+  const mapKey = R.pipe(mapKeyPairs, R.fromPairs);
+
+  // @dts-jest:pass:snap
+  mapKeyPairs((key: string) => `x${key}`, { a: 1, b: 2, c: 3 }); //=> [['xa', 1], ['xb', 2], ['xc', 3]]
+  // @dts-jest:pass:snap
+  mapKey((key: string) => `x${key}`, { a: 1, b: 2, c: 3 }); //=> { xa: 1, xb: 2, xc: 3 }
+})();


### PR DESCRIPTION
Fixes #273 

This PR adds tuple support for `R.adjust`, but it's disabled by default since TS may pick wrong kind for list, you have to specify kind manually, e.g. `R.adjust<"111", "tuple">` or other types satisfied the tuple kind.

**NOTE**: the tuple version of `R.adjust` only supports `fn: (x: T) => T`, does not support `fn: (x: T) => U` since AFAIK there's no way to "adjust" a tuple type.

```ts
// @dts-jest:pass:snap -> [string, number]
R.adjust<'111', 'tuple'>()(string_to_string, 0, string_number_tuple);
// @dts-jest:fail:snap -> Argument of type 'Morphism<string, string>' is not assignable to parameter of type 'Morphism<number, number>'.
R.adjust<'111', 'tuple'>()(string_to_string, 1, string_number_tuple);
```

```diff
import * as R from 'ramda';

export const mapKeys = R.curry(
- (fn: ???, obj: { [k: string]: any } | { [k: number]: any }) =>
+ (fn: (key: string) => string, obj: { [k: string]: any } | { [k: number]: any }) =>
    R.fromPairs(
      R.map(
-       R.adjust(fn, 0), // <--- Error: tried typings for `adjust`
+       R.adjust<0, [string, any]>(fn, 0),
        R.toPairs(obj) // Fixed by referencing typings of `toPairs`
      )
    )
);
```