### PR TITLE
chore(deps): update typescript to v2.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ TypeScript's type definitions for [Ramda](https://github.com/ramda/ramda)
 
 ## Status
 
-Typing compatible with Ramda v0.25.0 and TypeScript v2.5+
+Typing compatible with Ramda v0.25.0 and TypeScript v2.6.1 (strictFunctionTypes: false)
 
 ***Note***: many of the functions in Ramda are still hard to properly type in Ramda, with issues mainly centered around partial application, currying, and composition, especially so in the presence of generics. And yes, those are probably why you'd be using Ramda in the first place, making these issues particularly problematic to type Ramda for TypeScript. A few links to issues at TS can be found [below](#Roadmap).
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "tslint-config-ikatyang": "2.5.1",
     "tslint-config-prettier": "1.6.0",
     "tslint-plugin-prettier": "1.3.0",
-    "typescript": "2.5.3",
+    "typescript": "2.6.1",
     "yargs": "10.0.3"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es6",
     "strict": true,
+    "target": "es6",
     "module": "commonjs"
   },
   "include": [

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "strict": true,
+    "strictFunctionTypes": false,
     "target": "es6",
     "module": "commonjs",
     "types": []

--- a/yarn.lock
+++ b/yarn.lock
@@ -3285,9 +3285,9 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@2.5.3:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"
+typescript@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.1.tgz#ef39cdea27abac0b500242d6726ab90e0c846631"
 
 typescript@^2.4.0:
   version "2.5.2"


### PR DESCRIPTION
There're some errors for `strictFunctionTypes: true`, but I'm not able to investigate it without vscode support, so this is just a quick pre-fix for #288.

The current vscode (v1.17) does not respect the new `strictFunctionTypes` flag, which is why there's error occurred in CLI but not on editor... confusing me a lot.

Closes #310