### PR TITLE
fix: use the most general selectable-overload by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/yargs": "8.0.2",
     "del": "3.0.0",
     "dts-element": "2.2.1",
-    "dts-element-fp": "1.1.1",
+    "dts-element-fp": "1.1.2",
     "dts-jest": "22.0.3",
     "glob": "7.1.2",
     "gulp": "3.9.1",

--- a/snapshots/ramda-tests.ts
+++ b/snapshots/ramda-tests.ts
@@ -1604,6 +1604,18 @@ import * as R from '../ramda/dist/index';
   R.map(arrayify, { a: 1, b: 'c' }); //=> { a: [1], b: ['c'] }
   // @dts-jest:skip { a: number[], b: string[] }
   R.map(arrayify)({ a: 1, b: 'c' }); //=> { a: [1], b: ['c'] }
+
+  R.pipe(
+    R.map(Number.parseInt),
+    // @dts-jest:fail:snap -> Argument of type 'reduce_110<any, any>' is not assignable to parameter of type '(v: map_mixed_11<number, any>) => any'.
+    R.reduce(R.max, 0), // raises error (#311)
+  );
+
+  // @dts-jest:pass:snap -> (v1: {}) => any
+  R.pipe(
+    R.map(Number.parseInt)(),
+    R.reduce(R.max, 0), // no error
+  );
 })();
 
 // @dts-jest:group mapAccum

--- a/tests/__snapshots__/ramda-tests.ts.snap
+++ b/tests/__snapshots__/ramda-tests.ts.snap
@@ -744,6 +744,20 @@ exports[`map R.map(double, [1, 2, 3]) 1`] = `"number[]"`;
 
 exports[`map R.map(double, { a: 1, b: 2, c: 3 }) 1`] = `"Record<\\"a\\" | \\"b\\" | \\"c\\", number>"`;
 
+exports[`map R.pipe(
+      R.map(Number.parseInt)(),
+      R.reduce(R.max, 0), // no error
+    ) 1`] = `"(v1: {}) => any"`;
+
+exports[`map R.reduce(R.max, 0) 1`] = `
+"Argument of type 'reduce_110<any, any>' is not assignable to parameter of type '(v: map_mixed_11<number, any>) => any'.
+  Types of parameters 'values' and 'v' are incompatible.
+    Type 'map_mixed_11<number, any>' is not assignable to type 'List<any>'.
+      Type 'Functor<number>' is not assignable to type 'List<any>'.
+        Type 'Functor<number>' is not assignable to type 'ArrayLike<any>'.
+          Property 'length' is missing in type 'Functor<number>'."
+`;
+
 exports[`mapAccum R.mapAccum(append)('0')(digits) 1`] = `"[string, string[]]"`;
 
 exports[`mapAccum R.mapAccum(append)('0', digits) 1`] = `"[string, string[]]"`;

--- a/tests/ramda-tests.ts
+++ b/tests/ramda-tests.ts
@@ -1604,6 +1604,18 @@ import * as R from '../ramda/dist/index';
   R.map(arrayify, { a: 1, b: 'c' }); //=> { a: [1], b: ['c'] }
   // @dts-jest:skip { a: number[], b: string[] }
   R.map(arrayify)({ a: 1, b: 'c' }); //=> { a: [1], b: ['c'] }
+
+  R.pipe(
+    R.map(Number.parseInt),
+    // @dts-jest:fail:snap
+    R.reduce(R.max, 0), // raises error (#311)
+  );
+
+  // @dts-jest:pass:snap
+  R.pipe(
+    R.map(Number.parseInt)(),
+    R.reduce(R.max, 0), // no error
+  );
 })();
 
 // @dts-jest:group mapAccum

--- a/yarn.lock
+++ b/yarn.lock
@@ -742,11 +742,11 @@ doctrine@^0.7.2:
     esutils "^1.1.6"
     isarray "0.0.1"
 
-dts-element-fp@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/dts-element-fp/-/dts-element-fp-1.1.1.tgz#73cedcb9b2982fec57276b028f815e9bfc64aba3"
+dts-element-fp@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/dts-element-fp/-/dts-element-fp-1.1.2.tgz#19fa791f44cdd870f4c398e7c668b2c59fcb306a"
   dependencies:
-    ramda "^0.24.1"
+    ramda "^0.25.0"
 
 dts-element@2.2.1:
   version "2.2.1"
@@ -2635,13 +2635,9 @@ qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
-ramda@0.25.0:
+ramda@0.25.0, ramda@^0.25.0:
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
-
-ramda@^0.24.1:
-  version "0.24.1"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.24.1.tgz#c3b7755197f35b8dc3502228262c4c91ddb6b857"
 
 randomatic@^1.1.3:
   version "1.1.7"


### PR DESCRIPTION
Workaround for #311 

This issue was fixed in ikatyang/dts-element-fp#80

- before: use the first signature's selectable-overload, i.e. `list` in this case
![image](https://user-images.githubusercontent.com/8341033/32663588-75e5785e-c669-11e7-8131-88bf4329880f.png)

- after: use the last (most general) signature's selectable-overload, i.e. `mixed` in this case
![image](https://user-images.githubusercontent.com/8341033/32663555-51756b46-c669-11e7-8596-79ce8c3afecb.png)



Closes #325