### PR TITLE
fix(pipeP): first fn should return `PromiseLike`

### DIFF
--- a/snapshots/ramda-tests.ts
+++ b/snapshots/ramda-tests.ts
@@ -2267,6 +2267,8 @@ import * as R from '../ramda/dist/index';
     (m: number) => Promise.resolve(m / 2),
     R.multiply(5),
   )(10);
+  // @dts-jest:fail:snap -> Argument of type '() => number' is not assignable to parameter of type '(v1: {}, v2: {}, v3: {}, v4: {}, v5: {}, v6: {}) => PromiseLike<{}>'.
+  R.pipeP(() => 1);
 })();
 
 // @dts-jest:group pluck

--- a/templates/pipeP.ts
+++ b/templates/pipeP.ts
@@ -7,6 +7,6 @@ export default create_composition_declarations(
   max_curry_level,
   6,
   x => x,
-  x => `PromiseLike<${x}> | ${x}`,
+  (x, i) => (i === 0 ? `PromiseLike<${x}>` : `PromiseLike<${x}> | ${x}`),
   x => `PromiseLike<${x}>`,
 );

--- a/templates/utils/create-composition-declarations.ts
+++ b/templates/utils/create-composition-declarations.ts
@@ -9,11 +9,14 @@ export const create_composition_declarations = (
   // istanbul ignore next
   generate_function_parameter_type: (generic: string) => string = x => x,
   // istanbul ignore next
-  generate_function_return_type: (generic: string) => string = x => x,
-  // istanbul ignore next
-  generate_composed_return_type: (
+  generate_function_return_type: (
     generic: string,
-  ) => string = generate_function_return_type,
+    index: number,
+  ) => string = x => x,
+  // istanbul ignore next
+  generate_composed_return_type = generate_function_return_type as (
+    generic: string,
+  ) => string,
 ) => {
   const function_names = R.repeat(0, max_function_count).map(
     (_, index) => `fn${index + 1}`,
@@ -81,12 +84,16 @@ export const create_composition_declarations = (
               return index === entry_index
                 ? `${function_name}: (${entry_parameters}) => ${generate_function_return_type(
                     return_generic,
+                    index,
                   )}`
                 : `${function_name}: (v: ${generate_function_parameter_type(
                     current_sorted_return_generics[
                       index + (kind === 'compose' ? 1 : -1)
                     ],
-                  )}) => ${generate_function_return_type(return_generic)}`;
+                  )}) => ${generate_function_return_type(
+                    return_generic,
+                    index,
+                  )}`;
             })
             .join(',')}
         ): (${entry_parameters}) => ${generate_composed_return_type(

--- a/tests/__snapshots__/ramda-tests.ts.snap
+++ b/tests/__snapshots__/ramda-tests.ts.snap
@@ -1089,6 +1089,11 @@ exports[`pipeP R.pipeP(
       (m: number) => Promise.resolve(m / 2),
     )(10) 1`] = `"PromiseLike<number>"`;
 
+exports[`pipeP R.pipeP(() => 1) 1`] = `
+"Argument of type '() => number' is not assignable to parameter of type '(v1: {}, v2: {}, v3: {}, v4: {}, v5: {}, v6: {}) => PromiseLike<{}>'.
+  Type 'number' is not assignable to type 'PromiseLike<{}>'."
+`;
+
 exports[`pluck R.pluck(
       'value',
       R.pick(['a'])({

--- a/tests/ramda-tests.ts
+++ b/tests/ramda-tests.ts
@@ -2267,6 +2267,8 @@ import * as R from '../ramda/dist/index';
     (m: number) => Promise.resolve(m / 2),
     R.multiply(5),
   )(10);
+  // @dts-jest:fail:snap
+  R.pipeP(() => 1);
 })();
 
 // @dts-jest:group pluck


### PR DESCRIPTION
Fixes #361