### PR TITLE
Use prepack instead of prepublish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_script:
 script:
 - yarn run lint
 - yarn run lint-dts
+- yarn run build
 - yarn run test-utils -- --ci --verbose --coverage
 - yarn run test -- --ci --testPathPattern='/tests/ramda-tests.ts' --verbose=false
 - yarn run test -- --ci --testPathPattern='/tests/[a-z_]+.ts'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "repository": "https://github.com/types/npm-ramda",
   "homepage": "https://github.com/types/npm-ramda#readme",
   "scripts": {
-    "prepublish": "yarn run build",
+    "prepack": "yarn run build",
     "lint": "tslint --project ./tsconfig.json",
     "lint-dts": "tslint -c ./templates/tslint.json \"templates/**/*.d.ts\"",
     "test": "jest --config ./jest.json",


### PR DESCRIPTION
`prepublish` is no longer the correct way to build before `publish`. The correct script to use is `prepack`. The reason for this is that `prepublish` runs after `pack` and before `publish`, and `pack` is the script which defines what is published during `publish`, i.e., the package being published is already created by the time `prepublish` is called. By building in `prepack` the package will be created properly during `pack` and then published during `publish`. Using `prepublish` relies on having an already-done, possibly stale build.