### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ TypeScript's type definitions for [Ramda](https://github.com/ramda/ramda)
 
 Typing compatible with `ramda@0.25.0` and `typescript@~2.6.1` (strictFunctionTypes: false)
 
-***Note***: many of the functions in Ramda are still hard to properly type in TypeScript, with issues mainly centered around partial application, currying, and composition, especially so in the presence of generics. And yes, those are probably why you'd be using Ramda in the first place, making these issues particularly problematic to type Ramda for TypeScript. A few links to issues at TS can be found [below](#Roadmap).
+***Note***: many of the functions in Ramda are still hard to properly type in TypeScript, with issues mainly centered around partial application, currying, and composition, especially so in the presence of generics. And yes, those are probably why you'd be using Ramda in the first place, making these issues particularly problematic to type Ramda for TypeScript.
 
 ## Features
 


### PR DESCRIPTION
The "Roadmap" clause is no longer available since https://github.com/types/npm-ramda/commit/8b02ee3f1ee9a93b4afc48b8e86e20f61be8caae.