### PR TITLE
fix: do not hang

### DIFF
--- a/templates/$operation.d.ts
+++ b/templates/$operation.d.ts
@@ -18,20 +18,21 @@ export type Same<T extends PropertyKey, U extends PropertyKey> = Diff<
 >;
 export type Merge<T, U> = Omit<T, keyof U> & U;
 
-// prettier-ignore
 export interface NumberStringMap {
-   0:  '0',  1:  '1',  2:  '2',  3:  '3',  4:  '4',  5:  '5',  6:  '6',  7:  '7',  8:  '8',  9:  '9',
-  10: '10', 11: '11', 12: '12', 13: '13', 14: '14', 15: '15', 16: '16', 17: '17', 18: '18', 19: '19',
-  20: '20', 21: '21', 22: '22', 23: '23', 24: '24', 25: '25', 26: '26', 27: '27', 28: '28', 29: '29',
-  [n: number]: string;
+  0: '0';
+  1: '1';
+  2: '2';
+  3: '3';
+  4: '4';
+  5: '5';
 }
 
-export type NumberToString<T extends number> = T extends never
-  ? never
-  : NumberStringMap[T];
+export type NumberToString<T extends number> = T extends keyof NumberStringMap
+  ? NumberStringMap[T]
+  : never;
 
 // symbols are un-enumerable even if it's "enumerable"
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties#Detection_Table
-export type KeyOf<T> =
-  | Exclude<keyof T, number | symbol>
-  | NumberToString<Extract<keyof T, number>>;
+export type KeyOf<T, K = keyof T> =
+  | Extract<K, string>
+  | NumberToString<Extract<K, number>>;

--- a/templates/$types.d.ts
+++ b/templates/$types.d.ts
@@ -63,13 +63,11 @@ export interface Ordered {
   valueOf(): string | number | boolean;
 }
 
-export type Tuple =
-  | [any]
-  | [any, any]
-  | [any, any, any]
-  | [any, any, any, any]
-  | [any, any, any, any, any]
-  | [any, any, any, any, any, any];
+export interface Tuple {
+  0: any;
+  [index: number]: any;
+  readonly length: number;
+}
 
 // ramda
 

--- a/templates/$types.d.ts
+++ b/templates/$types.d.ts
@@ -14,12 +14,12 @@ export type IndexedListMorphism<T, U> = (
   index: number,
   list: List<T>,
 ) => U;
-export type IndexedObjectMorphism<T, U, K extends string> = (
+export type IndexedObjectMorphism<T, U, K extends PropertyKey> = (
   value: T,
   index: number,
   object: Record<K, T>,
 ) => U;
-export type KeyedObjectMorphism<T, U, K extends string> = (
+export type KeyedObjectMorphism<T, U, K extends PropertyKey> = (
   value: T,
   key: K,
   object: Record<K, T>,


### PR DESCRIPTION
Fixes #402

The memory issue is caused by the `Tuple` type, probably too many comparison I guess. To avoid other memory issue in the future, I reduced the number of items in `NumberStringMap` as well.

I've tested it with @stephenkoo's project (https://github.com/types/npm-ramda/issues/311#issuecomment-406166019) and the empty project mentioned in #402, it does not hang after applying this fix.