### PR TITLE
feat: compatible with keyofStringsOnly

### DIFF
--- a/templates/$operation.d.ts
+++ b/templates/$operation.d.ts
@@ -1,4 +1,4 @@
-import { Morphism } from './$types';
+import { Morphism, PropKey } from './$types';
 
 export type DeepPartial<T> = { [K in keyof T]?: DeepPartial<T[K]> };
 
@@ -6,13 +6,11 @@ export type DeepPartial<T> = { [K in keyof T]?: DeepPartial<T[K]> };
 export type Evolver<T> = Morphism<T, T> | { [K in keyof T]?: Evolver<T[K]> };
 
 // from https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766
-export type Diff<T extends PropertyKey, U extends PropertyKey> = ({
-  [P in T]: P
-} &
+export type Diff<T extends PropKey, U extends PropKey> = ({ [P in T]: P } &
   { [P in U]: never } & { [x: string]: never })[T];
-export type Omit<T, K extends PropertyKey> = Pick<T, Diff<keyof T, K>>;
+export type Omit<T, K extends PropKey> = Pick<T, Diff<keyof T, K>>;
 
-export type Same<T extends PropertyKey, U extends PropertyKey> = Diff<
+export type Same<T extends PropKey, U extends PropKey> = Diff<
   T | U,
   Diff<T, U> | Diff<U, T>
 >;

--- a/templates/$types.d.ts
+++ b/templates/$types.d.ts
@@ -2,6 +2,7 @@
 
 export type Property = string | number | symbol;
 export type Path = List<Property>;
+export type PropKey = keyof any; // for backward compatibility (keyofStringsOnly)
 
 // general
 
@@ -14,12 +15,12 @@ export type IndexedListMorphism<T, U> = (
   index: number,
   list: List<T>,
 ) => U;
-export type IndexedObjectMorphism<T, U, K extends PropertyKey> = (
+export type IndexedObjectMorphism<T, U, K extends PropKey> = (
   value: T,
   index: number,
   object: Record<K, T>,
 ) => U;
-export type KeyedObjectMorphism<T, U, K extends PropertyKey> = (
+export type KeyedObjectMorphism<T, U, K extends PropKey> = (
   value: T,
   key: K,
   object: Record<K, T>,

--- a/templates/dissoc.d.ts
+++ b/templates/dissoc.d.ts
@@ -1,11 +1,11 @@
 import { Omit } from './$operation';
-import { Property } from './$types';
+import { Property, PropKey } from './$types';
 
 export function $keyof<T extends object, K extends keyof T>(
   property: K,
   object: T,
 ): Omit<T, K>;
-export function $record<U extends Record<V, any>, V extends PropertyKey>(
+export function $record<U extends Record<V, any>, V extends PropKey>(
   property: V,
   object: U,
 ): Omit<U, V>;


### PR DESCRIPTION
Fixes #400

Uses `keyof any` to get `PropertyKey` work on TS 2.9 (keyofStringsOnly) 

Related to Microsoft/TypeScript#23592.